### PR TITLE
Integration test: Repeating test suites with different containerized environments

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -25,5 +25,5 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: docker-compose.log
-          path: docker-compose.log
+          name: Test Logs
+          path: "*.log"

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 
 deployments/01-grafana-credentials.yml
 test/cmd/pingserver/server
-docker-compose.log
+*.log
 .vscode/
 .idea/
 

--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,6 @@ prepare-integration-test:
 	$(OCI_BIN) compose $(COMPOSE_ARGS) stop || true
 	$(OCI_BIN) compose $(COMPOSE_ARGS) rm -f || true
 	$(OCI_BIN) rmi -f $(shell $(OCI_BIN) images --format '{{.Repository}}:{{.Tag}}' | grep 'hatest-') || true
-	@echo "### Spinning up Compose cluster"
-	$(OCI_BIN) compose $(COMPOSE_ARGS)  up --detach
 
 .PHONY: cleanup-integration-test
 cleanup-integration-test:
@@ -144,6 +142,7 @@ cleanup-integration-test:
 	@echo "### Removing integration test Compose cluster"
 	$(OCI_BIN) compose $(COMPOSE_ARGS) stop
 	$(OCI_BIN) compose $(COMPOSE_ARGS) rm -f
+	$(OCI_BIN) rmi -f $(shell $(OCI_BIN) images --format '{{.Repository}}:{{.Tag}}' | grep 'hatest-') || true
 
 # TODO: provide coverage info for integration testing https://go.dev/blog/integration-test-coverage
 .PHONY: run-integration-test

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ GOARCH ?= amd64
 DOCKERHUB_USER ?= mariomac
 
 COMPOSE_ARGS ?= -f test/integration/docker-compose.yml
-COMPOSE_LOGS ?= docker-compose.log
 
 # Container image creation creation
 VERSION ?= latest
@@ -137,8 +136,6 @@ prepare-integration-test:
 
 .PHONY: cleanup-integration-test
 cleanup-integration-test:
-	@echo "### Storing integration tests Compose logs"
-	$(OCI_BIN) compose $(COMPOSE_ARGS) logs > $(COMPOSE_LOGS)
 	@echo "### Removing integration test Compose cluster"
 	$(OCI_BIN) compose $(COMPOSE_ARGS) stop
 	$(OCI_BIN) compose $(COMPOSE_ARGS) rm -f

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/go-playground/validator/v10 v10.11.2 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -63,9 +63,9 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
-	golang.org/x/net v0.7.0 // indirect
+	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.7.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	google.golang.org/grpc v1.53.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,9 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -334,8 +335,8 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=
-golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
+golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -392,8 +393,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
-golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
+golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/test/integration/components/docker/compose.go
+++ b/test/integration/components/docker/compose.go
@@ -1,0 +1,77 @@
+// Package docker provides some helpers to manage docker-compose clusters from the test suites
+package docker
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+)
+
+type Compose struct {
+	Path   string
+	Logger io.WriteCloser
+	Env    []string
+}
+
+func ComposeSuite(composeFile, logFile string) (*Compose, error) {
+	logs, err := os.OpenFile(logFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+	if err != nil {
+		return nil, err
+	}
+	return &Compose{
+		Path:   path.Join(composeFile),
+		Logger: logs,
+		Env:    os.Environ(),
+	}, nil
+}
+
+func (c *Compose) Up() error {
+	return c.command("up", "--build", "--detach")
+}
+
+func (c *Compose) Logs() error {
+	return c.command("logs")
+}
+
+func (c *Compose) Stop() error {
+	return c.command("stop")
+}
+
+func (c *Compose) Remove() error {
+	return c.command("rm", "-f")
+}
+
+func (c *Compose) command(args ...string) error {
+	cmdArgs := []string{"compose", "-f", c.Path}
+	cmdArgs = append(cmdArgs, args...)
+	cmd := exec.Command("docker", cmdArgs...)
+	cmd.Env = c.Env
+	if c.Logger != nil {
+		cmd.Stdout = c.Logger
+		cmd.Stderr = c.Logger
+	}
+	return cmd.Run()
+}
+
+func (c *Compose) Close() error {
+	var errs []string
+	if err := c.Logs(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := c.Stop(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := c.Remove(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := c.Logger.Close(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(errs, " / "))
+}

--- a/test/integration/components/testserver/Dockerfile_nodebug
+++ b/test/integration/components/testserver/Dockerfile_nodebug
@@ -1,0 +1,28 @@
+# Build the testserver binary
+# Docker command must be invoked from the projec root directory
+FROM golang:1.20 as builder
+
+ARG TARGETARCH
+
+ENV GOARCH=$TARGETARCH
+
+WORKDIR /src
+
+# Copy the go manifests and source
+COPY vendor/ vendor/
+COPY test/ test/
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Build
+RUN go build -o testserver -ldflags="-s -w" ./test/integration/components/testserver/testserver.go
+
+# Create final image from minimal + built binary
+#TODO: use minimal image
+FROM ubuntu:latest
+
+WORKDIR /
+COPY --from=builder /src/testserver .
+USER 0:0
+
+CMD [ "/testserver" ]

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   testserver:
     build:
       context: ../..
-      dockerfile: test/integration/components/testserver/Dockerfile
+      dockerfile: test/integration/components/testserver/Dockerfile${TESTSERVER_DOCKERFILE_SUFFIX}
     image: hatest-testserver
     ports:
       - "8080:8080"
@@ -36,9 +36,6 @@ services:
       LOG_LEVEL: "DEBUG"
       OTEL_EXPORTER_REPORT_TARGET: "true"
       OTEL_EXPORTER_REPORT_PEER: "true"
-    depends_on:
-      otelcol:
-        condition: service_started
 
   # OpenTelemetry Collector
   otelcol:
@@ -57,6 +54,11 @@ services:
       - "4318:4318"     # OTLP over HTTP receiver
       - "9464"          # Prometheus exporter
       - "8888"          # metrics endpoint
+    depends_on:
+      autoinstrumenter:
+        condition: service_started
+      prometheus:
+        condition: service_started
 
   # Prometheus
   prometheus:
@@ -70,8 +72,5 @@ services:
       - --web.route-prefix=/
     volumes:
       - ./configs/:/etc/prometheus
-    depends_on:
-      otelcol:
-        condition: service_started
     ports:
       - "9090:9090"

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -1,0 +1,33 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/ebpf-autoinstrument/test/integration/components/docker"
+)
+
+func TestSuite(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose.yml", "../../test-suite.log")
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+	defer func() {
+		require.NoError(t, compose.Close())
+	}()
+	t.Run("RED metrics", testREDMetricsHTTP)
+}
+
+// Same as Test suite, but the generated test image does not contain debug information
+func TestSuite_NoDebugInfo(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose.yml", "../../test-suite-nodebug.log")
+	compose.Env = append(compose.Env, `TESTSERVER_DOCKERFILE_SUFFIX=_nodebug`)
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+	defer func() {
+		require.NoError(t, compose.Close())
+	}()
+	t.Run("RED metrics", testREDMetricsHTTP)
+}

--- a/vendor/github.com/golang/protobuf/jsonpb/decode.go
+++ b/vendor/github.com/golang/protobuf/jsonpb/decode.go
@@ -386,8 +386,14 @@ func (u *Unmarshaler) unmarshalMessage(m protoreflect.Message, in []byte) error 
 }
 
 func isSingularWellKnownValue(fd protoreflect.FieldDescriptor) bool {
+	if fd.Cardinality() == protoreflect.Repeated {
+		return false
+	}
 	if md := fd.Message(); md != nil {
-		return md.FullName() == "google.protobuf.Value" && fd.Cardinality() != protoreflect.Repeated
+		return md.FullName() == "google.protobuf.Value"
+	}
+	if ed := fd.Enum(); ed != nil {
+		return ed.FullName() == "google.protobuf.NullValue"
 	}
 	return false
 }

--- a/vendor/golang.org/x/text/unicode/norm/forminfo.go
+++ b/vendor/golang.org/x/text/unicode/norm/forminfo.go
@@ -13,7 +13,7 @@ import "encoding/binary"
 // a rune to a uint16. The values take two forms.  For v >= 0x8000:
 //   bits
 //   15:    1 (inverse of NFD_QC bit of qcInfo)
-//   13..7: qcInfo (see below). isYesD is always true (no decompostion).
+//   13..7: qcInfo (see below). isYesD is always true (no decomposition).
 //    6..0: ccc (compressed CCC value).
 // For v < 0x8000, the respective rune has a decomposition and v is an index
 // into a byte array of UTF-8 decomposition sequences and additional info and

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -96,7 +96,7 @@ github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/protoc-gen-gogo/descriptor
 github.com/gogo/protobuf/sortkeys
 github.com/gogo/protobuf/types
-# github.com/golang/protobuf v1.5.2
+# github.com/golang/protobuf v1.5.3
 ## explicit; go 1.9
 github.com/golang/protobuf/jsonpb
 github.com/golang/protobuf/proto
@@ -300,7 +300,7 @@ golang.org/x/exp/constraints
 golang.org/x/exp/slices
 golang.org/x/exp/slog
 golang.org/x/exp/slog/internal/buffer
-# golang.org/x/net v0.7.0
+# golang.org/x/net v0.8.0
 ## explicit; go 1.17
 golang.org/x/net/http/httpguts
 golang.org/x/net/http2
@@ -316,7 +316,7 @@ golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 golang.org/x/sys/windows/registry
-# golang.org/x/text v0.7.0
+# golang.org/x/text v0.8.0
 ## explicit; go 1.17
 golang.org/x/text/internal/language
 golang.org/x/text/internal/language/compact


### PR DESCRIPTION
The aim of this PR is being able to run the integration tests both in services that embed debug info and services that don't. But it will be also useful to test the auto-instrumenter when, instead of the executable name, we specify the port name.

Now the docker-compose environment can be configured via environment. And instead of spinning it up/down from the Makefile, we do it from the Go tests.

The normal "Tests" will be now run as subtests of higher-level suites. Each suite will:
* Spinup the Docker cluster and optionally override the configuration.
* Run the subtests
* Destroy the Docker cluster

Now we have two suites:
1. the baseline suite that just runs the HTTP RED metrics test with the default values
2. a suite that forces the instrumented service to be built without debug information, and then run again the HTTP RED metrics test.

