### PR TITLE
Fixes go-offsets-tracker version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ prereqs:
 	@echo "### Check if prerequisites are met, and installing missing dependencies"
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2)
 	$(call go-install-tool,$(BPF2GO),github.com/cilium/ebpf/cmd/bpf2go@v0.10.0)
-	$(call go-install-tool,$(GO_OFFSETS_TRACKER),github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker@v0.1.3)
+	$(call go-install-tool,$(GO_OFFSETS_TRACKER),github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker@v0.1.4)
 
 .PHONY: lint
 lint: prereqs


### PR DESCRIPTION
Now you can run `make update-offsets` multiple times without any crash.