### PR TITLE
Traces server span and url fixes

### DIFF
--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"golang.org/x/exp/slog"
@@ -180,7 +181,7 @@ func getMetricEndpointOptions(cfg *MetricsConfig) ([]otlpmetrichttp.Option, erro
 	if murl.Scheme == "http" || murl.Scheme == "unix" {
 		opts = append(opts, otlpmetrichttp.WithInsecure())
 	}
-	if len(murl.Path) > 0 && murl.Path != "/" {
+	if len(murl.Path) > 0 && murl.Path != "/" && !strings.HasSuffix(murl.Path, "/v1/metrics") {
 		opts = append(opts, otlpmetrichttp.WithURLPath(murl.Path+"/v1/metrics"))
 	}
 	return opts, nil

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -1,0 +1,59 @@
+package otel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsEndpoint(t *testing.T) {
+	mcfg := MetricsConfig{
+		ServiceName:     "svc-name",
+		Endpoint:        "localhost:3131",
+		MetricsEndpoint: "localhost:3232",
+	}
+
+	t.Run("testing with two endpoints", func(t *testing.T) {
+		testMetricsEndpLen(t, 1, &mcfg)
+	})
+
+	mcfg = MetricsConfig{
+		ServiceName:     "svc-name",
+		Endpoint:        "localhost:3131",
+		MetricsEndpoint: "localhost:3232",
+	}
+
+	t.Run("testing with only metrics endpoint", func(t *testing.T) {
+		testMetricsEndpLen(t, 1, &mcfg)
+	})
+
+	mcfg.Endpoint = "localhost:3131"
+	mcfg.MetricsEndpoint = ""
+
+	t.Run("testing with only non-signal endpoint", func(t *testing.T) {
+		testMetricsEndpLen(t, 1, &mcfg)
+	})
+
+	mcfg.Endpoint = "http://localhost:3131"
+	t.Run("testing with insecure endpoint", func(t *testing.T) {
+		testMetricsEndpLen(t, 2, &mcfg)
+	})
+
+	mcfg.Endpoint = "http://localhost:3131/path_to_endpoint"
+	t.Run("testing with insecure endpoint and path", func(t *testing.T) {
+		testMetricsEndpLen(t, 3, &mcfg)
+	})
+
+	mcfg.Endpoint = "http://localhost:3131/v1/metrics"
+	t.Run("testing with insecure endpoint and containing v1/metrics", func(t *testing.T) {
+		testMetricsEndpLen(t, 2, &mcfg)
+	})
+}
+
+func testMetricsEndpLen(t *testing.T, expected int, mcfg *MetricsConfig) {
+	opts, err := getMetricEndpointOptions(mcfg)
+	require.NoError(t, err)
+	// otlptracehttp.Options are notoriously hard to compare, so we just test the length
+	assert.Equal(t, expected, len(opts))
+}

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -1,0 +1,62 @@
+package otel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTracesEndpoint(t *testing.T) {
+	tcfg := TracesConfig{
+		ServiceName:        "svc-name",
+		Endpoint:           "localhost:3131",
+		TracesEndpoint:     "localhost:3232",
+		MaxQueueSize:       4096,
+		MaxExportBatchSize: 4096,
+	}
+
+	t.Run("testing with two endpoints", func(t *testing.T) {
+		testTracesEndpLen(t, 1, &tcfg)
+	})
+
+	tcfg = TracesConfig{
+		ServiceName:        "svc-name",
+		TracesEndpoint:     "localhost:3232",
+		MaxQueueSize:       4096,
+		MaxExportBatchSize: 4096,
+	}
+
+	t.Run("testing with only trace endpoint", func(t *testing.T) {
+		testTracesEndpLen(t, 1, &tcfg)
+	})
+
+	tcfg.Endpoint = "localhost:3131"
+	tcfg.TracesEndpoint = ""
+
+	t.Run("testing with only non-signal endpoint", func(t *testing.T) {
+		testTracesEndpLen(t, 1, &tcfg)
+	})
+
+	tcfg.Endpoint = "http://localhost:3131"
+	t.Run("testing with insecure endpoint", func(t *testing.T) {
+		testTracesEndpLen(t, 2, &tcfg)
+	})
+
+	tcfg.Endpoint = "http://localhost:3131/path_to_endpoint"
+	t.Run("testing with insecure endpoint and path", func(t *testing.T) {
+		testTracesEndpLen(t, 3, &tcfg)
+	})
+
+	tcfg.Endpoint = "http://localhost:3131/v1/traces"
+	t.Run("testing with insecure endpoint and containing v1/traces", func(t *testing.T) {
+		testTracesEndpLen(t, 2, &tcfg)
+	})
+}
+
+func testTracesEndpLen(t *testing.T, expected int, tcfg *TracesConfig) {
+	opts, err := getTracesEndpointOptions(tcfg)
+	require.NoError(t, err)
+	// otlptracehttp.Options are notoriously hard to compare, so we just test the length
+	assert.Equal(t, expected, len(opts))
+}

--- a/pkg/pipe/instrumenter_test.go
+++ b/pkg/pipe/instrumenter_test.go
@@ -289,7 +289,7 @@ func matchTraceEvent(t *testing.T, name string, event collector.TraceRecord) {
 			string(semconv.NetHostPortKey):              "8080",
 			string(semconv.HTTPRequestContentLengthKey): "0",
 		},
-		Kind: ptrace.SpanKindInternal,
+		Kind: ptrace.SpanKindServer,
 	}, event)
 }
 
@@ -312,7 +312,7 @@ func matchGRPCTraceEvent(t *testing.T, name string, event collector.TraceRecord)
 			string(semconv.NetHostNameKey):       "127.0.0.1",
 			string(semconv.NetHostPortKey):       "8080",
 		},
-		Kind: ptrace.SpanKindInternal,
+		Kind: ptrace.SpanKindServer,
 	}, event)
 }
 

--- a/test/collector/collector.go
+++ b/test/collector/collector.go
@@ -93,7 +93,7 @@ func (tc *TestCollector) traceEvent(writer http.ResponseWriter, body []byte) {
 		forEach[ptrace.ScopeSpans](rs.ScopeSpans(), func(ss ptrace.ScopeSpans) {
 			forEach[ptrace.Span](ss.Spans(), func(s ptrace.Span) {
 				switch s.Kind() {
-				case ptrace.SpanKindInternal:
+				case ptrace.SpanKindServer, ptrace.SpanKindInternal:
 					tr := TraceRecord{
 						Kind:       s.Kind(),
 						Name:       s.Name(),


### PR DESCRIPTION
This PR changes the type of the external span in traces to be SpanKind = SpanKindServer. When we have the external span as server, we are able to produce metrics with just trace spans. The Tempo span metric generator is able to produce metrics.

While testing this functionality I noticed a small issue when using the `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and the `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` environment variables. As per the OTel spec, if we are using the non-signal specific environment variable (i.e. not using OTEL_EXPORTER_OTLP_ENDPOINT) we need to pass in the full URL for the traces or the metrics, including the /v1/traces and /v1/metrics suffixes -> https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#example-2. However, if our code noticed anything in the URL path (other than `/`), we'd append /v1/traces|metrics, technically, appending twice. 

To fix this issue, I changed the code to not append /v1/traces|metrics if that's the suffix. I believe this will work in all cases. 