### PR TITLE
Make pinned path unique and clean-up

### DIFF
--- a/pkg/ebpf/fs/pinning.go
+++ b/pkg/ebpf/fs/pinning.go
@@ -1,9 +1,16 @@
 package fs
 
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
 const (
-	PinnedRoot = "/sys/fs/bpf"
+	pinnedRoot = "/sys/fs/bpf/otelauto"
 )
 
 var (
 	PinnedMaps = []string{"ongoing_server_requests", "ongoing_goroutines"}
+	PinnedRoot = filepath.Join(pinnedRoot, strconv.Itoa(os.Getpid()))
 )

--- a/pkg/ebpf/fs/pinning.go
+++ b/pkg/ebpf/fs/pinning.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	pinnedRoot = "/sys/fs/bpf/otelauto"
+	pinnedRoot = "/var/run/otelauto"
 )
 
 var (


### PR DESCRIPTION
This is a follow-up PR to https://github.com/grafana/ebpf-autoinstrument/pull/87.

We make a unique path location based on the PID of the instrumenter. I had to move the shutdown hook registration to allow for clean-up of the pinned maps/path even in the case we didn't find any process to instrument.