### PR TITLE
Deployments and test files: replace full privileges by CAP_SYS_ADMIN

### DIFF
--- a/deployments/02-grafana-agent.yml
+++ b/deployments/02-grafana-agent.yml
@@ -68,7 +68,7 @@ spec:
         - name: grafana-agent
           image: grafana/agent:main
           command:
-            - "/usr/bin/agent"
+            - "/usr/bin/grafana-agent"
             - "run"
             - "/grafana-agent-config/agent-config.river"
           env:

--- a/deployments/03-instrumented-app.yml
+++ b/deployments/03-instrumented-app.yml
@@ -22,7 +22,7 @@ spec:
         - name: goblog
           image: mariomac/goblog:dev
           imagePullPolicy: IfNotPresent
-          command: ["/goblog"]
+          command: [ "/goblog" ]
           env:
             - name: "GOBLOG_CONFIG"
               value: "/sample/config.yml"
@@ -34,7 +34,9 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0
-            privileged: true # TODO: change by individual capabilities
+            capabilities:
+              add:
+                - SYS_ADMIN
           env:
             - name: PRINT_TRACES
               value: "true"

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -12,6 +12,7 @@ Requirements:
 - eBPF enabled in the host
 - The instrumented Go programs must have been compiled with Go 1.17 or higher
 - Administrative access to execute the instrumenter
+  - Or execute it from a user enabling the `SYS_ADMIN` capability.
 
 ## Downloading
 

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -25,7 +25,8 @@ services:
       - ./configs/:/configs
       - ../../testoutput:/coverage
     image: hatest-autoinstrumenter
-    privileged: true # TODO: replace by individual capabilities
+    cap_add:
+      - SYS_ADMIN
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"


### PR DESCRIPTION
Related to https://github.com/grafana/ebpf-autoinstrument/issues/91

As far as I see, only the already overloaded [CAP_SYS_ADMIN](https://man7.org/linux/man-pages/man7/capabilities.7.html) have the rights for mounting, so we can't split the capabilities into smaller, narrower capabilities.