### PR TITLE
Fix intermittent errors in trace spans comparisons

### DIFF
--- a/pkg/ebpf/nethttp/nethttp.go
+++ b/pkg/ebpf/nethttp/nethttp.go
@@ -109,13 +109,6 @@ func (p *GinTracer) Probes() map[string]ebpfcommon.FunctionPrograms {
 			Start:    p.bpfObjects.UprobeServeHTTP,
 			End:      p.bpfObjects.UprobeServeHttpReturn,
 		},
-		"net/http.(*connReader).startBackgroundRead": {
-			Start: p.bpfObjects.UprobeStartBackgroundRead,
-		},
-		"net/http.(*Client).send": {
-			Start: p.bpfObjects.UprobeClientSend,
-			End:   p.bpfObjects.UprobeClientSendReturn,
-		},
 	}
 }
 

--- a/pkg/export/debug/debug.go
+++ b/pkg/export/debug/debug.go
@@ -18,10 +18,11 @@ func PrinterNode(_ PrintEnabled) node.TerminalFunc[[]transform.HTTPRequestSpan] 
 	return func(input <-chan []transform.HTTPRequestSpan) {
 		for spans := range input {
 			for i := range spans {
+				reqStart, start, end := spans[i].Timings()
 				fmt.Printf("%s (%s[%s]) %v %s %s [%s]->[%s:%d] size:%dB\n",
-					spans[i].Start.Format("2006-01-02 15:04:05.12345"),
-					spans[i].End.Sub(spans[i].RequestStart),
-					spans[i].End.Sub(spans[i].Start),
+					start.Format("2006-01-02 15:04:05.12345"),
+					end.Sub(reqStart),
+					end.Sub(start),
 					spans[i].Status,
 					spans[i].Method,
 					spans[i].Path,

--- a/pkg/export/debug/debug.go
+++ b/pkg/export/debug/debug.go
@@ -18,11 +18,11 @@ func PrinterNode(_ PrintEnabled) node.TerminalFunc[[]transform.HTTPRequestSpan] 
 	return func(input <-chan []transform.HTTPRequestSpan) {
 		for spans := range input {
 			for i := range spans {
-				reqStart, start, end := spans[i].Timings()
+				t := spans[i].Timings()
 				fmt.Printf("%s (%s[%s]) %v %s %s [%s]->[%s:%d] size:%dB\n",
-					start.Format("2006-01-02 15:04:05.12345"),
-					end.Sub(reqStart),
-					end.Sub(start),
+					t.Start.Format("2006-01-02 15:04:05.12345"),
+					t.End.Sub(t.RequestStart),
+					t.End.Sub(t.Start),
 					spans[i].Status,
 					spans[i].Method,
 					spans[i].Path,

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -172,17 +172,19 @@ func (r *MetricsReporter) metricAttributes(span *transform.HTTPRequestSpan) []at
 }
 
 func (r *MetricsReporter) record(span *transform.HTTPRequestSpan, attrs []attribute.KeyValue) {
+	reqStart, _, end := span.Timings()
+	duration := end.Sub(reqStart).Seconds() * 1000
 	switch span.Type {
 	case transform.EventTypeHTTP:
 		// TODO: for more accuracy, there must be a way to set the metric time from the actual span end time
-		r.httpDuration.Record(context.TODO(), span.End.Sub(span.RequestStart).Seconds()*1000, attrs...)
+		r.httpDuration.Record(context.TODO(), duration, attrs...)
 		r.httpRequestSize.Record(context.TODO(), float64(span.ContentLength), attrs...)
 	case transform.EventTypeGRPC:
-		r.grpcDuration.Record(context.TODO(), span.End.Sub(span.RequestStart).Seconds()*1000, attrs...)
+		r.grpcDuration.Record(context.TODO(), duration, attrs...)
 	case transform.EventTypeGRPCClient:
-		r.grpcClientDuration.Record(context.TODO(), span.End.Sub(span.RequestStart).Seconds()*1000, attrs...)
+		r.grpcClientDuration.Record(context.TODO(), duration, attrs...)
 	case transform.EventTypeHTTPClient:
-		r.httpClientDuration.Record(context.TODO(), span.End.Sub(span.RequestStart).Seconds()*1000, attrs...)
+		r.httpClientDuration.Record(context.TODO(), duration, attrs...)
 		r.httpClientRequestSize.Record(context.TODO(), float64(span.ContentLength), attrs...)
 	}
 }

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -172,8 +172,8 @@ func (r *MetricsReporter) metricAttributes(span *transform.HTTPRequestSpan) []at
 }
 
 func (r *MetricsReporter) record(span *transform.HTTPRequestSpan, attrs []attribute.KeyValue) {
-	reqStart, _, end := span.Timings()
-	duration := end.Sub(reqStart).Seconds() * 1000
+	t := span.Timings()
+	duration := t.End.Sub(t.RequestStart).Seconds() * 1000
 	switch span.Type {
 	case transform.EventTypeHTTP:
 		// TODO: for more accuracy, there must be a way to set the metric time from the actual span end time

--- a/pkg/transform/spanner.go
+++ b/pkg/transform/spanner.go
@@ -88,14 +88,24 @@ func (s *HTTPRequestSpan) Inside(parent *HTTPRequestSpan) bool {
 	return s.RequestStart >= parent.RequestStart && s.End <= parent.End
 }
 
-func (s *HTTPRequestSpan) Timings() (time.Time, time.Time, time.Time) {
+type Timings struct {
+	RequestStart time.Time
+	Start        time.Time
+	End          time.Time
+}
+
+func (s *HTTPRequestSpan) Timings() Timings {
 	now := clocks.clock()
 	monoNow := clocks.monoClock()
 	startDelta := monoNow - time.Duration(s.Start)
 	endDelta := monoNow - time.Duration(s.End)
 	goStartDelta := monoNow - time.Duration(s.RequestStart)
 
-	return now.Add(-goStartDelta), now.Add(-startDelta), now.Add(-endDelta)
+	return Timings{
+		RequestStart: now.Add(-goStartDelta),
+		Start:        now.Add(-startDelta),
+		End:          now.Add(-endDelta),
+	}
 }
 
 func convert(trace *ebpfcommon.HTTPRequestTrace) HTTPRequestSpan {

--- a/pkg/transform/spanner_test.go
+++ b/pkg/transform/spanner_test.go
@@ -2,7 +2,6 @@ package transform
 
 import (
 	"testing"
-	"time"
 
 	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
 
@@ -58,8 +57,8 @@ func assertMatches(t *testing.T, span *HTTPRequestSpan, method, path, peer strin
 	assert.Equal(t, method, span.Method)
 	assert.Equal(t, peer, span.Peer)
 	assert.Equal(t, status, span.Status)
-	assert.Equal(t, int64(durationMs*1000000), int64(span.End.UnixNano()-span.Start.UnixNano()))
-	assert.Equal(t, int64(durationMs*1000000), int64(span.Start.UnixNano()-span.RequestStart.UnixNano()))
+	assert.Equal(t, int64(durationMs*1000000), int64(span.End-span.Start))
+	assert.Equal(t, int64(durationMs*1000000), int64(span.Start-span.RequestStart))
 }
 
 func TestRequestTraceParsing(t *testing.T) {
@@ -112,11 +111,8 @@ func makeSpanWithTimings(goStart, start, end uint64, cnv converter) HTTPRequestS
 }
 
 func TestSpanNesting(t *testing.T) {
-	now := time.Now()
-	cnv := converter{
-		monoClock: func() time.Duration { return 10000000 },
-		clock:     func() time.Time { return now },
-	}
+	cnv := newConverter()
+
 	a := makeSpanWithTimings(10000, 20000, 30000, cnv)
 	b := makeSpanWithTimings(10000, 30000, 40000, cnv)
 	assert.True(t, (&a).Inside(&b))

--- a/pkg/transform/spanner_test.go
+++ b/pkg/transform/spanner_test.go
@@ -62,40 +62,38 @@ func assertMatches(t *testing.T, span *HTTPRequestSpan, method, path, peer strin
 }
 
 func TestRequestTraceParsing(t *testing.T) {
-	cnv := newConverter()
-
 	t.Run("Test basic parsing", func(t *testing.T) {
 		tr := makeHTTPRequestTrace("POST", "/users", "127.0.0.1:1234", 200, 5)
-		s := cnv.convert(&tr)
+		s := convert(&tr)
 		assertMatches(t, &s, "POST", "/users", "127.0.0.1", 200, 5)
 	})
 
 	t.Run("Test with empty path and missing peer host", func(t *testing.T) {
 		tr := makeHTTPRequestTrace("GET", "", ":1234", 403, 6)
-		s := cnv.convert(&tr)
+		s := convert(&tr)
 		assertMatches(t, &s, "GET", "", "", 403, 6)
 	})
 
 	t.Run("Test with missing peer port", func(t *testing.T) {
 		tr := makeHTTPRequestTrace("GET", "/posts/1/1", "1234", 500, 1)
-		s := cnv.convert(&tr)
+		s := convert(&tr)
 		assertMatches(t, &s, "GET", "/posts/1/1", "1234", 500, 1)
 	})
 
 	t.Run("Test with invalid peer port", func(t *testing.T) {
 		tr := makeHTTPRequestTrace("GET", "/posts/1/1", "1234:aaa", 500, 1)
-		s := cnv.convert(&tr)
+		s := convert(&tr)
 		assertMatches(t, &s, "GET", "/posts/1/1", "1234", 500, 1)
 	})
 
 	t.Run("Test with GRPC request", func(t *testing.T) {
 		tr := makeGRPCRequestTrace("/posts/1/1", []byte{0x7f, 0, 0, 0x1}, 2, 1)
-		s := cnv.convert(&tr)
+		s := convert(&tr)
 		assertMatches(t, &s, "", "/posts/1/1", "127.0.0.1", 2, 1)
 	})
 }
 
-func makeSpanWithTimings(goStart, start, end uint64, cnv converter) HTTPRequestSpan {
+func makeSpanWithTimings(goStart, start, end uint64) HTTPRequestSpan {
 	tr := ebpfcommon.HTTPRequestTrace{
 		Type:              1,
 		Path:              [100]uint8{},
@@ -107,25 +105,23 @@ func makeSpanWithTimings(goStart, start, end uint64, cnv converter) HTTPRequestS
 		EndMonotimeNs:     end,
 	}
 
-	return cnv.convert(&tr)
+	return convert(&tr)
 }
 
 func TestSpanNesting(t *testing.T) {
-	cnv := newConverter()
-
-	a := makeSpanWithTimings(10000, 20000, 30000, cnv)
-	b := makeSpanWithTimings(10000, 30000, 40000, cnv)
+	a := makeSpanWithTimings(10000, 20000, 30000)
+	b := makeSpanWithTimings(10000, 30000, 40000)
 	assert.True(t, (&a).Inside(&b))
-	a = makeSpanWithTimings(10000, 20000, 30000, cnv)
-	b = makeSpanWithTimings(10000, 30000, 30000, cnv)
+	a = makeSpanWithTimings(10000, 20000, 30000)
+	b = makeSpanWithTimings(10000, 30000, 30000)
 	assert.True(t, (&a).Inside(&b))
-	a = makeSpanWithTimings(11000, 11000, 30000, cnv)
-	b = makeSpanWithTimings(10000, 30000, 30000, cnv)
+	a = makeSpanWithTimings(11000, 11000, 30000)
+	b = makeSpanWithTimings(10000, 30000, 30000)
 	assert.True(t, (&a).Inside(&b))
-	a = makeSpanWithTimings(11000, 11000, 30001, cnv)
-	b = makeSpanWithTimings(10000, 30000, 30000, cnv)
+	a = makeSpanWithTimings(11000, 11000, 30001)
+	b = makeSpanWithTimings(10000, 30000, 30000)
 	assert.False(t, (&a).Inside(&b))
-	a = makeSpanWithTimings(9999, 11000, 19999, cnv)
-	b = makeSpanWithTimings(10000, 30000, 30000, cnv)
+	a = makeSpanWithTimings(9999, 11000, 19999)
+	b = makeSpanWithTimings(10000, 30000, 30000)
 	assert.False(t, (&a).Inside(&b))
 }

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -152,7 +152,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 			if len(results) > 0 {
 				res := results[0]
 				require.Len(t, res.Value, 2)
-				assert.LessOrEqual(t, "3", res.Value[1])
+				assert.Equal(t, "3", res.Value[1])
 			}
 		})
 
@@ -168,7 +168,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 			if len(results) > 0 {
 				res := results[0]
 				require.Len(t, res.Value, 2)
-				assert.LessOrEqual(t, "3", res.Value[1])
+				assert.Equal(t, "3", res.Value[1])
 			}
 		})
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/grafana/ebpf-autoinstrument/pull/104. 

For the purpose of nested spans we compare where the client spans land to find the matching server span. The earlier approach used the wall-clock converted times, which can be unstable and in some local stress testing I noticed that sometimes the span nesting doesn't work properly.

I've changed the HTTPRequestSpan such that it contains the original mono time captured by the bpf probes, and we only convert to wall-clock time when we need to make the trace or metric span. This should also help with performance and memory consumption. Namely size metrics will never have to do any conversion on timestamps and we'll keep lower memory footprint on the span channel.

I also found a bug while investigating this issue, I had put the HTTP client probes on the Gin registration too, so they were firing double. The required modules should notice we need the HTTP eBPF program too. 