### PR TITLE
Bugfix: fail if the OTEL URLs does not include a schema

### DIFF
--- a/deployments/03-instrumented-app.yml
+++ b/deployments/03-instrumented-app.yml
@@ -38,12 +38,14 @@ spec:
               add:
                 - SYS_ADMIN
           env:
+            - name: SERVICE_NAME
+              value: "goblog"
             - name: PRINT_TRACES
               value: "true"
             - name: OPEN_PORT
               value: "8443"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: "grafana-agent:4318"
+              value: "http://grafana-agent:4318"
             - name: LOG_LEVEL
               value: "DEBUG"
 ---

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -227,6 +227,9 @@ func getMetricEndpointOptions(cfg *MetricsConfig) ([]otlpmetrichttp.Option, erro
 	if err != nil {
 		return nil, fmt.Errorf("parsing endpoint URL %s: %w", endpoint, err)
 	}
+	if murl.Scheme == "" || murl.Host == "" {
+		return nil, fmt.Errorf("URL %q must have a scheme and a host", endpoint)
+	}
 
 	opts := []otlpmetrichttp.Option{
 		otlpmetrichttp.WithEndpoint(murl.Host),

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -10,8 +10,8 @@ import (
 func TestMetricsEndpoint(t *testing.T) {
 	mcfg := MetricsConfig{
 		ServiceName:     "svc-name",
-		Endpoint:        "localhost:3131",
-		MetricsEndpoint: "localhost:3232",
+		Endpoint:        "https://localhost:3131",
+		MetricsEndpoint: "https://localhost:3232",
 	}
 
 	t.Run("testing with two endpoints", func(t *testing.T) {
@@ -20,15 +20,15 @@ func TestMetricsEndpoint(t *testing.T) {
 
 	mcfg = MetricsConfig{
 		ServiceName:     "svc-name",
-		Endpoint:        "localhost:3131",
-		MetricsEndpoint: "localhost:3232",
+		Endpoint:        "https://localhost:3131",
+		MetricsEndpoint: "https://localhost:3232",
 	}
 
 	t.Run("testing with only metrics endpoint", func(t *testing.T) {
 		testMetricsEndpLen(t, 1, &mcfg)
 	})
 
-	mcfg.Endpoint = "localhost:3131"
+	mcfg.Endpoint = "https://localhost:3131"
 	mcfg.MetricsEndpoint = ""
 
 	t.Run("testing with only non-signal endpoint", func(t *testing.T) {
@@ -56,4 +56,16 @@ func testMetricsEndpLen(t *testing.T, expected int, mcfg *MetricsConfig) {
 	require.NoError(t, err)
 	// otlptracehttp.Options are notoriously hard to compare, so we just test the length
 	assert.Equal(t, expected, len(opts))
+}
+
+func TestMissingSchemeInMetricsEndpoint(t *testing.T) {
+	opts, err := getMetricEndpointOptions(&MetricsConfig{Endpoint: "http://foo:3030"})
+	require.NoError(t, err)
+	require.NotEmpty(t, opts)
+
+	_, err = getMetricEndpointOptions(&MetricsConfig{Endpoint: "foo:3030"})
+	require.Error(t, err)
+
+	_, err = getMetricEndpointOptions(&MetricsConfig{Endpoint: "foo"})
+	require.Error(t, err)
 }

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -312,6 +312,9 @@ func getTracesEndpointOptions(cfg *TracesConfig) ([]otlptracehttp.Option, error)
 	if err != nil {
 		return nil, fmt.Errorf("parsing endpoint URL %s: %w", endpoint, err)
 	}
+	if murl.Scheme == "" || murl.Host == "" {
+		return nil, fmt.Errorf("URL %q must have a scheme and a host", endpoint)
+	}
 
 	opts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpoint(murl.Host),

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -10,8 +10,8 @@ import (
 func TestTracesEndpoint(t *testing.T) {
 	tcfg := TracesConfig{
 		ServiceName:        "svc-name",
-		Endpoint:           "localhost:3131",
-		TracesEndpoint:     "localhost:3232",
+		Endpoint:           "https://localhost:3131",
+		TracesEndpoint:     "https://localhost:3232",
 		MaxQueueSize:       4096,
 		MaxExportBatchSize: 4096,
 	}
@@ -22,7 +22,7 @@ func TestTracesEndpoint(t *testing.T) {
 
 	tcfg = TracesConfig{
 		ServiceName:        "svc-name",
-		TracesEndpoint:     "localhost:3232",
+		TracesEndpoint:     "https://localhost:3232",
 		MaxQueueSize:       4096,
 		MaxExportBatchSize: 4096,
 	}
@@ -31,7 +31,7 @@ func TestTracesEndpoint(t *testing.T) {
 		testTracesEndpLen(t, 1, &tcfg)
 	})
 
-	tcfg.Endpoint = "localhost:3131"
+	tcfg.Endpoint = "https://localhost:3131"
 	tcfg.TracesEndpoint = ""
 
 	t.Run("testing with only non-signal endpoint", func(t *testing.T) {
@@ -59,4 +59,16 @@ func testTracesEndpLen(t *testing.T, expected int, tcfg *TracesConfig) {
 	require.NoError(t, err)
 	// otlptracehttp.Options are notoriously hard to compare, so we just test the length
 	assert.Equal(t, expected, len(opts))
+}
+
+func TestMissingSchemeInTracesEndpoint(t *testing.T) {
+	opts, err := getTracesEndpointOptions(&TracesConfig{Endpoint: "http://foo:3030"})
+	require.NoError(t, err)
+	require.NotEmpty(t, opts)
+
+	_, err = getTracesEndpointOptions(&TracesConfig{Endpoint: "foo:3030"})
+	require.Error(t, err)
+
+	_, err = getTracesEndpointOptions(&TracesConfig{Endpoint: "foo"})
+	require.Error(t, err)
 }


### PR DESCRIPTION
If you didn't include the schema in the Metrics/Traces, endpoint, the autoinstrumenter started normally but then couldn't send metrcis/traces, showing this error in the logs.
```
2023/05/15 10:32:30 Post "https:///v1/metrics": http: no Host in request URL
```
This was caused by a URL like `foo:8080` being parsed with `foo`  as schema and no hostname.

This PR will cause the autoinstrumenter to fail at startup so the user can realize faster that the configuration is wrong.