### PR TITLE
Fix SpanMetrics integration

### DIFF
--- a/pkg/export/otel/common.go
+++ b/pkg/export/otel/common.go
@@ -1,0 +1,37 @@
+package otel
+
+import (
+	"context"
+
+	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+)
+
+// TODO: when we join both traces' and metrics ServiceName and ServiceNamespace into a common configuration section
+// provide a unique Resource for both metrics and traces reporter
+func otelResource(ctx context.Context, cfgSvcName, cfgSvcNamespace string) *resource.Resource {
+	// If service name is not explicitly set, we take the service name as set by the
+	// executable inspector
+	svcName := cfgSvcName
+	if svcName == "" {
+		svcName = global.Context(ctx).ServiceName
+	}
+
+	attrs := []attribute.KeyValue{
+		semconv.ServiceName(svcName),
+		// SpanMetrics requires an extra attribute besides service name
+		// to generate the traces_target_info metric,
+		// so the service is visible in the ServicesList
+		// This attribute also allows that App O11y plugin shows this app as a Go application.
+		// TODO: detect the runtime of the target executable and set this value accordingly
+		semconv.TelemetrySDKLanguageGo,
+	}
+
+	if cfgSvcNamespace != "" {
+		attrs = append(attrs, semconv.ServiceNamespace(cfgSvcNamespace))
+	}
+
+	return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
+}

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -83,6 +83,10 @@ func newTracesReporter(ctx context.Context, cfg *TracesConfig) (*TracesReporter,
 	resources := resource.NewWithAttributes(
 		semconv.SchemaURL,
 		semconv.ServiceNameKey.String(svcName),
+		// SpanMetrics requires an extra attribute besides service name
+		// to generate the traces_target_info metric,
+		// so the service is visible in the ServicesList
+		attribute.Key("reporter").String(reporterName),
 	)
 
 	// Instantiate the OTLP HTTP traceExporter

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       PRINT_TRACES: "true"
       OPEN_PORT: "${OPEN_PORT}"
       EXECUTABLE_NAME: "${EXECUTABLE_NAME}"
+      SERVICE_NAMESPACE: "integration-test"
       METRICS_INTERVAL: "10ms"
       BPF_BATCH_TIMEOUT: "10ms"
       LOG_LEVEL: "DEBUG"

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -104,6 +104,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 		results, err = pq.Query(`http_server_duration_seconds_count{` +
 			`http_method="GET",` +
 			`http_status_code="404",` +
+			`service_namespace="integration-test",` +
 			`service_name="testserver",` +
 			`http_route="/basic/:rnd",` +
 			`http_target="` + path + `"}`)
@@ -124,6 +125,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 		results, err = pq.Query(`http_server_request_size_bytes_count{` +
 			`http_method="GET",` +
 			`http_status_code="404",` +
+			`service_namespace="integration-test",` +
 			`service_name="testserver",` +
 			`http_route="/basic/:rnd",` +
 			`http_target="` + path + `"}`)
@@ -145,6 +147,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 			results, err = pq.Query(`http_client_duration_seconds_count{` +
 				`http_method="GET",` +
 				`http_status_code="203",` +
+				`service_namespace="integration-test",` +
 				`service_name="testserver"}`)
 			require.NoError(t, err)
 			// check duration_count has 3 calls
@@ -161,6 +164,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 			results, err = pq.Query(`http_client_request_size_bytes_count{` +
 				`http_method="GET",` +
 				`http_status_code="203",` +
+				`service_namespace="integration-test",` +
 				`service_name="testserver"}`)
 			require.NoError(t, err)
 			// check duration_count has 3 calls
@@ -177,6 +181,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 			results, err = pq.Query(`rpc_client_duration_seconds_count{` +
 				`rpc_grpc_status_code="0",` +
 				`service_name="testserver",` +
+				`service_namespace="integration-test",` +
 				`rpc_method="/routeguide.RouteGuide/GetFeature"}`)
 			require.NoError(t, err)
 			// check duration_count has at least 3 calls
@@ -195,6 +200,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 		`http_method="GET",` +
 		`http_status_code="404",` +
 		`service_name="testserver",` +
+		`service_namespace="integration-test",` +
 		`http_route="/basic/:rnd",` +
 		`http_target="` + path + `"}`)
 	require.NoError(t, err)
@@ -213,6 +219,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 		`http_method="GET",` +
 		`http_status_code="404",` +
 		`service_name="testserver",` +
+		`service_namespace="integration-test",` +
 		`http_route="/basic/:rnd",` +
 		`http_target="` + path + `"}`)
 	require.NoError(t, err)
@@ -242,6 +249,7 @@ func testREDMetricsGRPC(t *testing.T) {
 		var err error
 		results, err = pq.Query(`rpc_server_duration_seconds_count{` +
 			`rpc_grpc_status_code="0",` +
+			`service_namespace="integration-test",` +
 			`service_name="testserver",` +
 			`rpc_method="/routeguide.RouteGuide/GetFeature"}`)
 		require.NoError(t, err)


### PR DESCRIPTION
SpanMetrics requires any extra attribute besides service name to generate the traces_target_info metric, so the service is visible in the Services List of the App O11y Grafana plugin.

It enables a given runtime information attribute so the list of applications can show an Icon about the executable runtime (now only Go it's possible). It also enables configuring the service namespace so it appears in the App O11y list of services:

<img width="1353" alt="image" src="https://github.com/grafana/ebpf-autoinstrument/assets/939550/c35cf906-5c92-4723-a482-bef723c329b7">

