### PR TITLE
Simplified Signal Handling

### DIFF
--- a/cmd/otelauto/main.go
+++ b/cmd/otelauto/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"golang.org/x/exp/slog"
 
@@ -60,6 +61,11 @@ func main() {
 	bp.Run(ctx)
 
 	slog.Info("exiting auto-instrumenter")
+
+	if gc := os.Getenv("GOCOVERDIR"); gc != "" {
+		slog.Info("Waiting 1s to collect coverage data...")
+		time.Sleep(time.Second)
+	}
 }
 
 func loadConfig(configPath *string) *pipe.Config {

--- a/cmd/otelauto/main.go
+++ b/cmd/otelauto/main.go
@@ -46,14 +46,7 @@ func main() {
 	// Adding shutdown hook for graceful stop.
 	// We must register the hook before we launch the pipe build, otherwise we won't clean up if the
 	// child process isn't found.
-	ctx, cancel := context.WithCancel(context.Background())
-	exit := make(chan os.Signal, 1)
-	signal.Notify(exit, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		sig := <-exit
-		slog.Debug("Received termination signal", "signal", sig.String())
-		cancel()
-	}()
+	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	slog.Info("creating instrumentation pipeline")
 	bp, err := pipe.Build(ctx, config)

--- a/test/integration/components/testserver/testserver.go
+++ b/test/integration/components/testserver/testserver.go
@@ -26,7 +26,7 @@ type config struct {
 	// GinPort to listen connections using the Gin framework
 	GinPort int `env:"GIN_PORT" envDefault:"8081"`
 	// GorillaPort to listen connections using the Gorilla Mux framework
-	GorillaPort int    `env:"GIN_PORT" envDefault:"8082"`
+	GorillaPort int    `env:"GORILLA_PORT" envDefault:"8082"`
 	LogLevel    string `env:"LOG_LEVEL" envDefault:"INFO"`
 }
 


### PR DESCRIPTION
The other day I realized this new function, which seems to be available from Go 1.16.

It also adds minor fixes:
- If runtime coverage is enabled, leave few time to collect it.
- Fixes an integration test env var.