### PR TITLE
Histogram buckets fix + copy of Grafana Dashboard

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1,0 +1,831 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 30,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "json-view"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration (ms)"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 13,
+        "x": 0,
+        "y": 0
+      },
+      "id": 35,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 2,
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Duration (ms)"
+          }
+        ]
+      },
+      "pluginVersion": "9.5.3-cloud.2.0cb5a501",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sort_desc(topk by(http_route, job) (5,  max by (http_route, job) (histogram_quantile(0.95,  (sum by(http_route, job, le) (rate(http_server_duration_bucket[$__rate_interval])))))))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "{{job}} - {{http_route}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Slowest HTTP routes (P95)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Duration (ms)",
+            "binary": {
+              "left": "Value",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "1000"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Duration (ms)": 4,
+              "Time": 1,
+              "Value": 3,
+              "http_route": 2,
+              "job": 0
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "json-view"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration (ms)"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 11,
+        "x": 13,
+        "y": 0
+      },
+      "id": 56,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 2,
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Duration (ms)"
+          }
+        ]
+      },
+      "pluginVersion": "9.5.3-cloud.2.0cb5a501",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sort_desc(topk by(rpc_method, job) (5,  max by (rpc_method, job) (histogram_quantile(0.95,  (sum by(rpc_method, job, le) (rate(rpc_server_duration_bucket[$__rate_interval])))))))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "{{job}} - {{http_route}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Slowest RPC methods (P95)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Duration (ms)",
+            "binary": {
+              "left": "Value",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "1000"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 5,
+      "panels": [],
+      "repeat": "Service",
+      "repeatDirection": "h",
+      "title": "$Service",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Metrics}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 63,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(job, le) (rate(http_client_duration_bucket{job=\"$Service\"}[$__rate_interval])))",
+          "legendFormat": "HTTP p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(http_client_duration_bucket{job=\"$Service\"}[$__rate_interval])) by (job, le)) ",
+          "hide": false,
+          "legendFormat": "HTTP p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_client_duration_sum{job=\"$Service\"} [$__rate_interval])) / sum(rate(http_client_duration_count{job=\"$Service\"} [$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "HTTP Avg",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rpc_client_duration_sum{job=\"$Service\"} [$__rate_interval])) / sum(rate(rpc_client_duration_count{job=\"$Service\"} [$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "RPC Avg",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(job, le) (rate(rpc_client_duration_bucket{job=\"$Service\"}[$__rate_interval])))",
+          "hide": false,
+          "legendFormat": "RPC p99",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(rpc_client_duration_bucket{job=\"$Service\"}[$__rate_interval])) by (job, le)) ",
+          "hide": false,
+          "legendFormat": "RPC p95",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Duration (client)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Metrics}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 63,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.99, sum by(job, le) (rate(http_server_duration_bucket{job=\"$Service\"}[$__rate_interval])))",
+          "legendFormat": "HTTP p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_duration_bucket{job=\"$Service\"}[$__rate_interval])) by (job, le))",
+          "hide": false,
+          "legendFormat": "HTTP p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_duration_sum{job=\"$Service\"} [$__rate_interval])) / sum(rate(http_server_duration_count{job=\"$Service\"} [$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "HTTP Avg",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.99, sum by(job, le) (rate(rpc_server_duration_bucket{job=\"$Service\"}[$__rate_interval])))",
+          "hide": false,
+          "legendFormat": "RPC p99",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.95, sum by(job, le) (rate(rpc_server_duration_bucket{job=\"$Service\"}[$__rate_interval])))",
+          "hide": false,
+          "legendFormat": "RPC p95",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rpc_server_duration_sum{job=\"$Service\"} [$__rate_interval])) / sum(rate(rpc_server_duration_count{job=\"$Service\"} [$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "RPC Avg",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Duration (server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Metrics}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_client_duration_count{job=\"$Service\"} [$__rate_interval])) by (job, http_status_code)",
+          "legendFormat": "HTTP client - {{http_status_code}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_duration_count{job=\"$Service\"} [$__rate_interval])) by (job, http_status_code)",
+          "hide": false,
+          "legendFormat": "HTTP server - {{http_status_code}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rpc_client_duration_count{job=\"$Service\"} [$__rate_interval])) by (job, rpc_grpc_status_code)",
+          "hide": false,
+          "legendFormat": "RPC client (status {{rpc_grpc_status_code}})",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rpc_server_duration_count{job=\"$Service\"} [$__rate_interval])) by (job, rpc_grpc_status_code)",
+          "hide": false,
+          "legendFormat": "RPC server (status {{rpc_grpc_status_code}})",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "grafanacloud-mariomacias-prom",
+          "value": "grafanacloud-mariomacias-prom"
+        },
+        "description": "Source of the metrics (e.g. Prometheus source)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "Metrics",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "grafanacloud-prom"
+        },
+        "definition": "label_values(job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "Service",
+        "options": [],
+        "query": {
+          "query": "label_values(job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "eBPF RED Metrics",
+  "uid": "e0701985-a623-4e62-9fae-f5094244d065",
+  "version": 37,
+  "weekStart": ""
+}

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
-
 	"golang.org/x/exp/slog"
 
+	"github.com/grafana/ebpf-autoinstrument/pkg/export/otel"
+	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
 	"github.com/grafana/ebpf-autoinstrument/pkg/transform"
 	"github.com/mariomac/pipes/pkg/node"
 	"github.com/prometheus/client_golang/prometheus"
@@ -88,20 +88,24 @@ func newReporter(ctx context.Context, cfg *PrometheusConfig) *metricsReporter {
 		reportRoutes: reportRoutes,
 		registry:     prometheus.NewRegistry(),
 		httpDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: HTTPServerDuration,
-			Help: "duration of HTTP service calls from the server side, in milliseconds",
+			Name:    HTTPServerDuration,
+			Help:    "duration of HTTP service calls from the server side, in milliseconds",
+			Buckets: otel.DurationHistogramBoundaries,
 		}, labelNamesHTTP(cfg, reportRoutes)),
 		httpClientDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: HTTPClientDuration,
-			Help: "duration of HTTP service calls from the client side, in milliseconds",
+			Name:    HTTPClientDuration,
+			Help:    "duration of HTTP service calls from the client side, in milliseconds",
+			Buckets: otel.DurationHistogramBoundaries,
 		}, labelNamesHTTPClient(cfg)),
 		grpcDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: RPCServerDuration,
-			Help: "duration of RCP service calls from the server side, in milliseconds",
+			Name:    RPCServerDuration,
+			Help:    "duration of RCP service calls from the server side, in milliseconds",
+			Buckets: otel.DurationHistogramBoundaries,
 		}, labelNamesGRPC(cfg)),
 		grpcClientDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: RPCClientDuration,
-			Help: "duration of GRPC service calls from the client side, in milliseconds",
+			Name:    RPCClientDuration,
+			Help:    "duration of GRPC service calls from the client side, in milliseconds",
+			Buckets: otel.DurationHistogramBoundaries,
 		}, labelNamesGRPC(cfg)),
 		httpRequestSize: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name: HTTPServerRequestSize,


### PR DESCRIPTION
Copied here an initial version of the Grafana Dashboard (screenshot below). It also fixes the buckets according to the OTEL recommendations so the histogram data is meaningful.


<img width="1506" alt="Screenshot 2023-05-26 at 15 46 14" src="https://github.com/grafana/ebpf-autoinstrument/assets/939550/89f94653-c186-44fd-bb75-60b5de400069">
