### PR TITLE
Fix linter and unit tests in Darwin

### DIFF
--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -2,12 +2,10 @@ package ebpfcommon
 
 import (
 	"io"
-	"syscall"
 	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/grafana/ebpf-autoinstrument/pkg/goexec"
-	"golang.org/x/sys/unix"
 )
 
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target bpf -type http_request_trace bpf ../../../bpf/http_trace.c -- -I../../../bpf/headers
@@ -68,8 +66,4 @@ type FunctionPrograms struct {
 type Filter struct {
 	io.Closer
 	Fd int
-}
-
-func (f *Filter) Close() error {
-	return syscall.SetsockoptInt(f.Fd, unix.SOL_SOCKET, unix.SO_DETACH_BPF, 0)
 }

--- a/pkg/ebpf/common/common_linux.go
+++ b/pkg/ebpf/common/common_linux.go
@@ -1,0 +1,11 @@
+package ebpfcommon
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func (f *Filter) Close() error {
+	return syscall.SetsockoptInt(f.Fd, unix.SOL_SOCKET, unix.SO_DETACH_BPF, 0)
+}

--- a/pkg/ebpf/instrumenter_darwin.go
+++ b/pkg/ebpf/instrumenter_darwin.go
@@ -1,0 +1,11 @@
+package ebpf
+
+import (
+	"github.com/cilium/ebpf"
+)
+
+// placeholder to avoid Darwin linter and unit tests to fail
+
+func attachSocketFilter(_ *ebpf.Program) (int, error) {
+	return 0, nil
+}

--- a/pkg/ebpf/instrumenter_linux.go
+++ b/pkg/ebpf/instrumenter_linux.go
@@ -1,0 +1,38 @@
+package ebpf
+
+import (
+	"encoding/binary"
+	"syscall"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
+)
+
+func attachSocketFilter(filter *ebpf.Program) (int, error) {
+	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ALL)))
+	if err == nil {
+		ssoErr := syscall.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_ATTACH_BPF, filter.FD())
+		if ssoErr != nil {
+			return -1, ssoErr
+		}
+		return fd, nil
+	}
+
+	return -1, err
+}
+
+func isLittleEndian() bool {
+	var a uint16 = 1
+
+	return *(*byte)(unsafe.Pointer(&a)) == 1
+}
+
+func htons(a uint16) uint16 {
+	if isLittleEndian() {
+		var arr [2]byte
+		binary.LittleEndian.PutUint16(arr[:], a)
+		return binary.BigEndian.Uint16(arr[:])
+	}
+	return a
+}


### PR DESCRIPTION
Moves some symbols that are only available on Linux to its own `_linux.go` file.