### PR TITLE
Add service name and optimize transforms

### DIFF
--- a/pkg/ebpf/grpc/grpc.go
+++ b/pkg/ebpf/grpc/grpc.go
@@ -15,7 +15,9 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"io"
 	"unsafe"
 
@@ -23,6 +25,7 @@ import (
 	"github.com/grafana/ebpf-autoinstrument/pkg/exec"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/ringbuf"
 	"github.com/grafana/ebpf-autoinstrument/pkg/goexec"
 	"golang.org/x/exp/slog"
 )
@@ -101,10 +104,22 @@ func (p *Tracer) SocketFilters() []*ebpf.Program {
 	return nil
 }
 
-func (p *Tracer) Run(ctx context.Context, eventsChan chan<- []ebpfcommon.HTTPRequestTrace) {
+func (p *Tracer) Run(ctx context.Context, eventsChan chan<- []interface{}) {
 	logger := slog.With("component", "grpc.Tracer")
 	ebpfcommon.ForwardRingbuf(
-		p.Cfg, logger, p.bpfObjects.Events, nil,
+		p.Cfg, logger, p.bpfObjects.Events, p.toRequestTrace,
 		append(p.closers, &p.bpfObjects)...,
 	)(ctx, eventsChan)
+}
+
+func (p *Tracer) toRequestTrace(record *ringbuf.Record) (interface{}, error) {
+	var event ebpfcommon.HTTPRequestTrace
+
+	err := binary.Read(bytes.NewBuffer(record.RawSample), binary.LittleEndian, &event)
+	if err != nil {
+		slog.Error("Error reading generic HTTP event", err)
+		return nil, err
+	}
+
+	return event, nil
 }

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -55,14 +55,14 @@ type Tracer interface {
 	SocketFilters() []*ebpf.Program
 	// Run will do the action of listening for eBPF traces and forward them
 	// periodically to the output channel.
-	Run(context.Context, chan<- []ebpfcommon.HTTPRequestTrace)
+	Run(context.Context, chan<- []interface{})
 	// AddCloser adds io.Closer instances that need to be invoked when the
 	// Run function ends.
 	AddCloser(c ...io.Closer)
 }
 
 // TracerProvider returns a StartFuncCtx for each discovered eBPF traceable source: GRPC, HTTP...
-func TracerProvider(ctx context.Context, cfg ebpfcommon.TracerConfig) ([]node.StartFuncCtx[[]ebpfcommon.HTTPRequestTrace], error) { //nolint:all
+func TracerProvider(ctx context.Context, cfg ebpfcommon.TracerConfig) ([]node.StartFuncCtx[[]interface{}], error) { //nolint:all
 	var log = logger()
 
 	// Each program is an eBPF source: net/http, grpc...
@@ -114,7 +114,7 @@ func TracerProvider(ctx context.Context, cfg ebpfcommon.TracerConfig) ([]node.St
 	// startNodes contains the eBPF programs (HTTP, GRPC tracers...) plus a function
 	// that just waits for the passed context to finish before closing the BPF pin
 	// path
-	startNodes := []node.StartFuncCtx[[]ebpfcommon.HTTPRequestTrace]{
+	startNodes := []node.StartFuncCtx[[]interface{}]{
 		waitToCloseBbfPinPath(pinPath),
 	}
 
@@ -190,8 +190,8 @@ func logger() *slog.Logger { return slog.With("component", "ebpf.TracerProvider"
 
 // this will be just a start node that listens for the context cancellation and then
 // unmounts the BPF pinning path
-func waitToCloseBbfPinPath(pinPath string) node.StartFuncCtx[[]ebpfcommon.HTTPRequestTrace] {
-	return func(ctx context.Context, _ chan<- []ebpfcommon.HTTPRequestTrace) {
+func waitToCloseBbfPinPath(pinPath string) node.StartFuncCtx[[]interface{}] {
+	return func(ctx context.Context, _ chan<- []interface{}) {
 		<-ctx.Done()
 		unmountBpfPinPath(pinPath)
 	}

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -28,6 +28,7 @@ type SessionSpan struct {
 
 var topSpans, _ = lru.New[uint64, SessionSpan](8192)
 var clientSpans, _ = lru.New[uint64, []transform.HTTPRequestSpan](8192)
+var namedTracers, _ = lru.New[string, *trace.TracerProvider](512)
 
 const reporterName = "github.com/grafana/ebpf-autoinstrument"
 
@@ -58,6 +59,7 @@ type TracesReporter struct {
 	ctx           context.Context
 	traceExporter *otlptrace.Exporter
 	traceProvider *trace.TracerProvider
+	bsp           trace.SpanProcessor
 }
 
 func TracesReporterProvider(ctx context.Context, cfg TracesConfig) (node.TerminalFunc[[]transform.HTTPRequestSpan], error) { //nolint:gocritic
@@ -71,8 +73,6 @@ func TracesReporterProvider(ctx context.Context, cfg TracesConfig) (node.Termina
 
 func newTracesReporter(ctx context.Context, cfg *TracesConfig) (*TracesReporter, error) {
 	r := TracesReporter{ctx: ctx}
-
-	resources := otelResource(ctx, cfg.ServiceName, cfg.ServiceNamespace)
 
 	// Instantiate the OTLP HTTP traceExporter
 	topts, err := getTracesEndpointOptions(cfg)
@@ -98,10 +98,11 @@ func newTracesReporter(ctx context.Context, cfg *TracesConfig) (*TracesReporter,
 		opts = append(opts, trace.WithExportTimeout(cfg.ExportTimeout))
 	}
 
-	bsp := trace.NewBatchSpanProcessor(r.traceExporter, opts...)
+	resource := otelResource(ctx, cfg.ServiceName, cfg.ServiceNamespace)
+	r.bsp = trace.NewBatchSpanProcessor(r.traceExporter, opts...)
 	r.traceProvider = trace.NewTracerProvider(
-		trace.WithResource(resources),
-		trace.WithSpanProcessor(bsp),
+		trace.WithResource(resource),
+		trace.WithSpanProcessor(r.bsp),
 	)
 
 	return &r, nil
@@ -116,10 +117,11 @@ func (r *TracesReporter) close() {
 	}
 }
 
-func traceAttributes(span *transform.HTTPRequestSpan) []attribute.KeyValue {
+func (r *TracesReporter) traceAttributes(span *transform.HTTPRequestSpan) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
 	switch span.Type {
 	case transform.EventTypeHTTP:
-		attrs := []attribute.KeyValue{
+		attrs = []attribute.KeyValue{
 			semconv.HTTPMethod(span.Method),
 			semconv.HTTPStatusCode(span.Status),
 			semconv.HTTPTarget(span.Path),
@@ -131,9 +133,8 @@ func traceAttributes(span *transform.HTTPRequestSpan) []attribute.KeyValue {
 		if span.Route != "" {
 			attrs = append(attrs, semconv.HTTPRoute(span.Route))
 		}
-		return attrs
 	case transform.EventTypeGRPC:
-		return []attribute.KeyValue{
+		attrs = []attribute.KeyValue{
 			semconv.RPCMethod(span.Path),
 			semconv.RPCSystemGRPC,
 			semconv.RPCGRPCStatusCodeKey.Int(span.Status),
@@ -142,7 +143,7 @@ func traceAttributes(span *transform.HTTPRequestSpan) []attribute.KeyValue {
 			semconv.NetHostPort(span.HostPort),
 		}
 	case transform.EventTypeHTTPClient:
-		return []attribute.KeyValue{
+		attrs = []attribute.KeyValue{
 			semconv.HTTPMethod(span.Method),
 			semconv.HTTPStatusCode(span.Status),
 			semconv.HTTPURL(span.Path),
@@ -151,7 +152,7 @@ func traceAttributes(span *transform.HTTPRequestSpan) []attribute.KeyValue {
 			semconv.HTTPRequestContentLength(int(span.ContentLength)),
 		}
 	case transform.EventTypeGRPCClient:
-		return []attribute.KeyValue{
+		attrs = []attribute.KeyValue{
 			semconv.RPCMethod(span.Path),
 			semconv.RPCSystemGRPC,
 			semconv.RPCGRPCStatusCodeKey.Int(span.Status),
@@ -159,7 +160,12 @@ func traceAttributes(span *transform.HTTPRequestSpan) []attribute.KeyValue {
 			semconv.NetPeerPort(span.HostPort),
 		}
 	}
-	return []attribute.KeyValue{}
+
+	if span.ServiceName != "" { // we don't have service name set, system wide instrumentation
+		attrs = append(attrs, semconv.ServiceName(span.ServiceName))
+	}
+
+	return attrs
 }
 
 func traceName(span *transform.HTTPRequestSpan) string {
@@ -188,14 +194,14 @@ func spanKind(span *transform.HTTPRequestSpan) trace2.SpanKind {
 	return trace2.SpanKindInternal
 }
 
-func makeSpan(parentCtx context.Context, tracer trace2.Tracer, span *transform.HTTPRequestSpan) SessionSpan {
+func (r *TracesReporter) makeSpan(parentCtx context.Context, tracer trace2.Tracer, span *transform.HTTPRequestSpan) SessionSpan {
 	t := span.Timings()
 
 	// Create a parent span for the whole request session
 	ctx, sp := tracer.Start(parentCtx, traceName(span),
 		trace2.WithTimestamp(t.RequestStart),
 		trace2.WithSpanKind(spanKind(span)),
-		trace2.WithAttributes(traceAttributes(span)...),
+		trace2.WithAttributes(r.traceAttributes(span)...),
 	)
 
 	if span.RequestStart != span.Start {
@@ -246,49 +252,72 @@ func (r *TracesReporter) reportClientSpan(span *transform.HTTPRequestSpan, trace
 		}
 	}
 
-	makeSpan(ctx, tracer, span)
+	r.makeSpan(ctx, tracer, span)
 }
 
 func (r *TracesReporter) reportServerSpan(span *transform.HTTPRequestSpan, tracer trace2.Tracer) {
-	s := makeSpan(r.ctx, tracer, span)
-	topSpans.Add(span.ID, s)
-	cs, ok := clientSpans.Get(span.ID)
-	newer := []transform.HTTPRequestSpan{}
-	if ok {
-		// finish any client spans that were waiting for this parent span
-		for j := range cs {
-			cspan := &cs[j]
-			if cspan.Inside(span) {
-				makeSpan(s.RootCtx, tracer, cspan)
-			} else if cspan.Start > span.RequestStart {
-				newer = append(newer, *cspan)
-			} else {
-				makeSpan(r.ctx, tracer, cspan)
+
+	s := r.makeSpan(r.ctx, tracer, span)
+	if span.ID != 0 {
+		topSpans.Add(span.ID, s)
+		cs, ok := clientSpans.Get(span.ID)
+		newer := []transform.HTTPRequestSpan{}
+		if ok {
+			// finish any client spans that were waiting for this parent span
+			for j := range cs {
+				cspan := &cs[j]
+				if cspan.Inside(span) {
+					r.makeSpan(s.RootCtx, tracer, cspan)
+				} else if cspan.Start > span.RequestStart {
+					newer = append(newer, *cspan)
+				} else {
+					r.makeSpan(r.ctx, tracer, cspan)
+				}
 			}
-		}
-		if len(newer) == 0 {
-			clientSpans.Remove(span.ID)
-		} else {
-			clientSpans.Add(span.ID, newer)
+			if len(newer) == 0 {
+				clientSpans.Remove(span.ID)
+			} else {
+				clientSpans.Add(span.ID, newer)
+			}
 		}
 	}
 }
 
 func (r *TracesReporter) reportTraces(input <-chan []transform.HTTPRequestSpan) {
 	defer r.close()
-	tracer := r.traceProvider.Tracer(reporterName)
+	defaultTracer := r.traceProvider.Tracer(reporterName)
 	for spans := range input {
 		for i := range spans {
+			spanTracer := defaultTracer
 			span := &spans[i]
+
+			if span.ServiceName != "" {
+				spanTracer = r.namedTracer(span.ServiceName)
+			}
 
 			switch span.Type {
 			case transform.EventTypeHTTPClient, transform.EventTypeGRPCClient:
-				r.reportClientSpan(span, tracer)
+				r.reportClientSpan(span, spanTracer)
 			case transform.EventTypeHTTP, transform.EventTypeGRPC:
-				r.reportServerSpan(span, tracer)
+				r.reportServerSpan(span, spanTracer)
 			}
 		}
 	}
+}
+
+func (r *TracesReporter) namedTracer(comm string) trace2.Tracer {
+	traceProvider, ok := namedTracers.Get(comm)
+
+	if !ok {
+		resource := otelResource(r.ctx, comm, "")
+		traceProvider = trace.NewTracerProvider(
+			trace.WithResource(resource),
+			trace.WithSpanProcessor(r.bsp),
+		)
+		namedTracers.Add(comm, traceProvider)
+	}
+
+	return traceProvider.Tracer(reporterName)
 }
 
 func getTracesEndpointOptions(cfg *TracesConfig) ([]otlptracehttp.Option, error) {

--- a/pkg/pipe/instrumenter_test.go
+++ b/pkg/pipe/instrumenter_test.go
@@ -33,8 +33,8 @@ func TestBasicPipeline(t *testing.T) {
 
 	gb := newGraphBuilder(&Config{Metrics: otel.MetricsConfig{MetricsEndpoint: tc.ServerEndpoint, ReportTarget: true, ReportPeerInfo: true}})
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]ebpfcommon.HTTPRequestTrace], error) {
-		return func(_ context.Context, out chan<- []ebpfcommon.HTTPRequestTrace) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]interface{}], error) {
+		return func(_ context.Context, out chan<- []interface{}) {
 			out <- newRequest(1, "GET", "/foo/bar", "1.1.1.1:3456", 404)
 		}, nil
 	})
@@ -66,8 +66,8 @@ func TestTracerPipeline(t *testing.T) {
 
 	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, ServiceName: "test"}})
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]ebpfcommon.HTTPRequestTrace], error) {
-		return func(_ context.Context, out chan<- []ebpfcommon.HTTPRequestTrace) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]interface{}], error) {
+		return func(_ context.Context, out chan<- []interface{}) {
 			out <- newRequest(1, "GET", "/foo/bar", "1.1.1.1:3456", 404)
 		}, nil
 	})
@@ -96,8 +96,8 @@ func TestRouteConsolidation(t *testing.T) {
 		Routes:  &transform.RoutesConfig{Patterns: []string{"/user/{id}", "/products/{id}/push"}},
 	})
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]ebpfcommon.HTTPRequestTrace], error) {
-		return func(_ context.Context, out chan<- []ebpfcommon.HTTPRequestTrace) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]interface{}], error) {
+		return func(_ context.Context, out chan<- []interface{}) {
 			out <- newRequest(1, "GET", "/user/1234", "1.1.1.1:3456", 200)
 			out <- newRequest(2, "GET", "/products/3210/push", "1.1.1.1:3456", 200)
 			out <- newRequest(3, "GET", "/attach", "1.1.1.1:3456", 200) // undefined route: won't report as route
@@ -158,8 +158,8 @@ func TestGRPCPipeline(t *testing.T) {
 
 	gb := newGraphBuilder(&Config{Metrics: otel.MetricsConfig{MetricsEndpoint: tc.ServerEndpoint, ReportTarget: true, ReportPeerInfo: true}})
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]ebpfcommon.HTTPRequestTrace], error) {
-		return func(_ context.Context, out chan<- []ebpfcommon.HTTPRequestTrace) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]interface{}], error) {
+		return func(_ context.Context, out chan<- []interface{}) {
 			out <- newGRPCRequest(1, "/foo/bar", 3)
 		}, nil
 	})
@@ -191,8 +191,8 @@ func TestTraceGRPCPipeline(t *testing.T) {
 
 	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, ServiceName: "test"}})
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]ebpfcommon.HTTPRequestTrace], error) {
-		return func(_ context.Context, out chan<- []ebpfcommon.HTTPRequestTrace) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]interface{}], error) {
+		return func(_ context.Context, out chan<- []interface{}) {
 			out <- newGRPCRequest(1, "foo.bar", 3)
 		}, nil
 	})
@@ -218,8 +218,8 @@ func TestNestedSpanMatching(t *testing.T) {
 
 	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, ServiceName: "test"}})
 	// Override eBPF tracer to send some fake data with nested client span
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]ebpfcommon.HTTPRequestTrace], error) {
-		return func(_ context.Context, out chan<- []ebpfcommon.HTTPRequestTrace) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ ebpfcommon.TracerConfig) (node.StartFuncCtx[[]interface{}], error) {
+		return func(_ context.Context, out chan<- []interface{}) {
 			out <- newRequestWithTiming(1, transform.EventTypeHTTPClient, "GET", "/attach", "2.2.2.2:1234", 200, 60000, 60000, 70000)
 			out <- newRequestWithTiming(1, transform.EventTypeHTTP, "GET", "/user/1234", "1.1.1.1:3456", 200, 10000, 10000, 50000)
 			out <- newRequestWithTiming(3, transform.EventTypeHTTPClient, "GET", "/products/3210/pull", "2.2.2.2:3456", 204, 80000, 80000, 90000)
@@ -288,7 +288,7 @@ func TestNestedSpanMatching(t *testing.T) {
 	assert.Equal(t, parent1ID, event.Attributes["parent_span_id"])
 }
 
-func newRequest(id uint64, method, path, peer string, status int) []ebpfcommon.HTTPRequestTrace {
+func newRequest(id uint64, method, path, peer string, status int) []interface{} {
 	rt := ebpfcommon.HTTPRequestTrace{}
 	copy(rt.Path[:], path)
 	copy(rt.Method[:], method)
@@ -300,10 +300,10 @@ func newRequest(id uint64, method, path, peer string, status int) []ebpfcommon.H
 	rt.GoStartMonotimeNs = 1
 	rt.StartMonotimeNs = 2
 	rt.EndMonotimeNs = 3
-	return []ebpfcommon.HTTPRequestTrace{rt}
+	return []interface{}{rt}
 }
 
-func newRequestWithTiming(id uint64, kind transform.EventType, method, path, peer string, status int, goStart, start, end uint64) []ebpfcommon.HTTPRequestTrace {
+func newRequestWithTiming(id uint64, kind transform.EventType, method, path, peer string, status int, goStart, start, end uint64) []interface{} {
 	rt := ebpfcommon.HTTPRequestTrace{}
 	copy(rt.Path[:], path)
 	copy(rt.Method[:], method)
@@ -315,10 +315,10 @@ func newRequestWithTiming(id uint64, kind transform.EventType, method, path, pee
 	rt.GoStartMonotimeNs = goStart
 	rt.StartMonotimeNs = start
 	rt.EndMonotimeNs = end
-	return []ebpfcommon.HTTPRequestTrace{rt}
+	return []interface{}{rt}
 }
 
-func newGRPCRequest(id uint64, path string, status int) []ebpfcommon.HTTPRequestTrace {
+func newGRPCRequest(id uint64, path string, status int) []interface{} {
 	rt := ebpfcommon.HTTPRequestTrace{}
 	copy(rt.Path[:], path)
 	copy(rt.RemoteAddr[:], []byte{0x1, 0x1, 0x1, 0x1})
@@ -332,7 +332,7 @@ func newGRPCRequest(id uint64, path string, status int) []ebpfcommon.HTTPRequest
 	rt.GoStartMonotimeNs = 1
 	rt.StartMonotimeNs = 2
 	rt.EndMonotimeNs = 3
-	return []ebpfcommon.HTTPRequestTrace{rt}
+	return []interface{}{rt}
 }
 
 func getHostname() string {

--- a/pkg/transform/spanner.go
+++ b/pkg/transform/spanner.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
+	httpfltr "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/httpfltr"
 
 	"github.com/gavv/monotime"
 	"golang.org/x/exp/slog"
@@ -46,13 +47,23 @@ type HTTPRequestSpan struct {
 	RequestStart  int64
 	Start         int64
 	End           int64
+	ServiceName   string
 }
 
-func ConvertToSpan(in <-chan []ebpfcommon.HTTPRequestTrace, out chan<- []HTTPRequestSpan) {
+func ConvertToSpan(in <-chan []interface{}, out chan<- []HTTPRequestSpan) {
 	for traces := range in {
 		spans := make([]HTTPRequestSpan, 0, len(traces))
 		for i := range traces {
-			spans = append(spans, convert(&traces[i]))
+			v := traces[i]
+
+			switch t := v.(type) {
+			case ebpfcommon.HTTPRequestTrace:
+				httpTrace := t
+				spans = append(spans, convertFromHTTPTrace(&httpTrace))
+			case httpfltr.HTTPInfo:
+				info := t
+				spans = append(spans, convertFromHTTPInfo(&info))
+			}
 		}
 		out <- spans
 	}
@@ -112,7 +123,7 @@ func (s *HTTPRequestSpan) Timings() Timings {
 	}
 }
 
-func convert(trace *ebpfcommon.HTTPRequestTrace) HTTPRequestSpan {
+func convertFromHTTPTrace(trace *ebpfcommon.HTTPRequestTrace) HTTPRequestSpan {
 	// From C, assuming 0-ended strings
 	methodLen := bytes.IndexByte(trace.Method[:], 0)
 	if methodLen < 0 {
@@ -154,5 +165,23 @@ func convert(trace *ebpfcommon.HTTPRequestTrace) HTTPRequestSpan {
 		Start:         int64(trace.StartMonotimeNs),
 		End:           int64(trace.EndMonotimeNs),
 		Status:        int(trace.Status),
+	}
+}
+
+func convertFromHTTPInfo(info *httpfltr.HTTPInfo) HTTPRequestSpan {
+	return HTTPRequestSpan{
+		Type:          EventType(info.Type),
+		ID:            0,
+		Method:        info.Method,
+		Path:          info.URL,
+		Peer:          info.Peer,
+		Host:          info.Host,
+		HostPort:      int(info.ConnInfo.D_port),
+		ContentLength: 0,
+		RequestStart:  int64(info.StartMonotimeNs),
+		Start:         int64(info.StartMonotimeNs),
+		End:           int64(info.EndMonotimeNs),
+		Status:        int(info.Status),
+		ServiceName:   info.Comm,
 	}
 }

--- a/pkg/transform/spanner_test.go
+++ b/pkg/transform/spanner_test.go
@@ -64,31 +64,31 @@ func assertMatches(t *testing.T, span *HTTPRequestSpan, method, path, peer strin
 func TestRequestTraceParsing(t *testing.T) {
 	t.Run("Test basic parsing", func(t *testing.T) {
 		tr := makeHTTPRequestTrace("POST", "/users", "127.0.0.1:1234", 200, 5)
-		s := convert(&tr)
+		s := convertFromHTTPTrace(&tr)
 		assertMatches(t, &s, "POST", "/users", "127.0.0.1", 200, 5)
 	})
 
 	t.Run("Test with empty path and missing peer host", func(t *testing.T) {
 		tr := makeHTTPRequestTrace("GET", "", ":1234", 403, 6)
-		s := convert(&tr)
+		s := convertFromHTTPTrace(&tr)
 		assertMatches(t, &s, "GET", "", "", 403, 6)
 	})
 
 	t.Run("Test with missing peer port", func(t *testing.T) {
 		tr := makeHTTPRequestTrace("GET", "/posts/1/1", "1234", 500, 1)
-		s := convert(&tr)
+		s := convertFromHTTPTrace(&tr)
 		assertMatches(t, &s, "GET", "/posts/1/1", "1234", 500, 1)
 	})
 
 	t.Run("Test with invalid peer port", func(t *testing.T) {
 		tr := makeHTTPRequestTrace("GET", "/posts/1/1", "1234:aaa", 500, 1)
-		s := convert(&tr)
+		s := convertFromHTTPTrace(&tr)
 		assertMatches(t, &s, "GET", "/posts/1/1", "1234", 500, 1)
 	})
 
 	t.Run("Test with GRPC request", func(t *testing.T) {
 		tr := makeGRPCRequestTrace("/posts/1/1", []byte{0x7f, 0, 0, 0x1}, 2, 1)
-		s := convert(&tr)
+		s := convertFromHTTPTrace(&tr)
 		assertMatches(t, &s, "", "/posts/1/1", "127.0.0.1", 2, 1)
 	})
 }
@@ -105,7 +105,7 @@ func makeSpanWithTimings(goStart, start, end uint64) HTTPRequestSpan {
 		EndMonotimeNs:     end,
 	}
 
-	return convert(&tr)
+	return convertFromHTTPTrace(&tr)
 }
 
 func TestSpanNesting(t *testing.T) {


### PR DESCRIPTION
This PR adds support for tracking the service name in both metrics and traces, when we use system wide instrumentation.

I also refactored the code a bit to allow for different types of records from the ring buffer. The previous implementation for the http filter used two separate transformations, one to convert to HTTPRequestTrace and then it was later converted to HTTPRequestSpan.