### PR TITLE
Updated dashboard

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -45,7 +45,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -120,7 +121,7 @@
           }
         ]
       },
-      "pluginVersion": "9.5.3-cloud.2.0cb5a501",
+      "pluginVersion": "10.0.0-cloud.3.b04cc88b",
       "targets": [
         {
           "datasource": {
@@ -197,7 +198,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -272,7 +274,7 @@
           }
         ]
       },
-      "pluginVersion": "9.5.3-cloud.2.0cb5a501",
+      "pluginVersion": "10.0.0-cloud.3.b04cc88b",
       "targets": [
         {
           "datasource": {
@@ -320,11 +322,11 @@
         "x": 0,
         "y": 5
       },
-      "id": 5,
+      "id": 72,
       "panels": [],
       "repeat": "Service",
       "repeatDirection": "h",
-      "title": "$Service",
+      "title": "Inbound: $Service",
       "type": "row"
     },
     {
@@ -372,7 +374,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -388,158 +391,6 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 6
-      },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Metrics}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(job, le) (rate(http_client_duration_bucket{job=\"$Service\"}[$__rate_interval])))",
-          "legendFormat": "HTTP p99",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Metrics}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(http_client_duration_bucket{job=\"$Service\"}[$__rate_interval])) by (job, le)) ",
-          "hide": false,
-          "legendFormat": "HTTP p95",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Metrics}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(http_client_duration_sum{job=\"$Service\"} [$__rate_interval])) / sum(rate(http_client_duration_count{job=\"$Service\"} [$__rate_interval]))",
-          "hide": false,
-          "legendFormat": "HTTP Avg",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Metrics}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(rpc_client_duration_sum{job=\"$Service\"} [$__rate_interval])) / sum(rate(rpc_client_duration_count{job=\"$Service\"} [$__rate_interval]))",
-          "hide": false,
-          "legendFormat": "RPC Avg",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Metrics}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(job, le) (rate(rpc_client_duration_bucket{job=\"$Service\"}[$__rate_interval])))",
-          "hide": false,
-          "legendFormat": "RPC p99",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Metrics}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(rpc_client_duration_bucket{job=\"$Service\"}[$__rate_interval])) by (job, le)) ",
-          "hide": false,
-          "legendFormat": "RPC p95",
-          "range": true,
-          "refId": "F"
-        }
-      ],
-      "title": "Duration (client)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${Metrics}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 63,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 3,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
         "y": 6
       },
       "id": 1,
@@ -628,7 +479,7 @@
           "refId": "F"
         }
       ],
-      "title": "Duration (server)",
+      "title": "Duration",
       "type": "timeseries"
     },
     {
@@ -676,7 +527,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -691,8 +543,413 @@
       "gridPos": {
         "h": 8,
         "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 58,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_duration_count{job=\"$Service\"} [$__rate_interval])) by (http_status_code)",
+          "hide": false,
+          "legendFormat": "HTTP server - {{http_status_code}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rpc_server_duration_count{job=\"$Service\"} [$__rate_interval])) by (job, rpc_grpc_status_code)",
+          "hide": false,
+          "legendFormat": "RPC server (status {{rpc_grpc_status_code}})",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Request rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Metrics}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "HTTP server - 500"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
         "x": 16,
         "y": 6
+      },
+      "id": 59,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_status_code) (rate(http_server_duration_count{job=\"$Service\",http_status_code=~\"(4|5).*\"}[$__rate_interval])) / ignoring(http_status_code) group_left sum(rate(http_server_duration_count{job=\"$Service\"}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "HTTP server - {{http_status_code}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (rpc_grpc_status_code) (rate(rpc_server_duration_count{job=\"$Service\",rpc_grpc_status_code!=\"0\"}[$__rate_interval])) / ignoring(rpc_grpc_status_code) group_left sum(rate(rpc_server_duration_count{job=\"$Service\"}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "RPC server (status {{rpc_grpc_status_code}})",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Error rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 5,
+      "panels": [],
+      "repeat": "Service",
+      "repeatDirection": "h",
+      "title": "Outbound: $Service",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Metrics}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 63,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 51
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(job, le) (rate(http_client_duration_bucket{job=\"$Service\"}[$__rate_interval])))",
+          "legendFormat": "HTTP p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(http_client_duration_bucket{job=\"$Service\"}[$__rate_interval])) by (job, le)) ",
+          "hide": false,
+          "legendFormat": "HTTP p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_client_duration_sum{job=\"$Service\"} [$__rate_interval])) / sum(rate(http_client_duration_count{job=\"$Service\"} [$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "HTTP Avg",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rpc_client_duration_sum{job=\"$Service\"} [$__rate_interval])) / sum(rate(rpc_client_duration_count{job=\"$Service\"} [$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "RPC Avg",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(job, le) (rate(rpc_client_duration_bucket{job=\"$Service\"}[$__rate_interval])))",
+          "hide": false,
+          "legendFormat": "RPC p99",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(rpc_client_duration_bucket{job=\"$Service\"}[$__rate_interval])) by (job, le)) ",
+          "hide": false,
+          "legendFormat": "RPC p95",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Metrics}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 51
       },
       "id": 8,
       "options": {
@@ -725,9 +982,128 @@
             "uid": "${Metrics}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_server_duration_count{job=\"$Service\"} [$__rate_interval])) by (job, http_status_code)",
+          "expr": "sum(rate(rpc_client_duration_count{job=\"$Service\"} [$__rate_interval])) by (job, rpc_grpc_status_code)",
           "hide": false,
-          "legendFormat": "HTTP server - {{http_status_code}}",
+          "legendFormat": "RPC client (status {{rpc_grpc_status_code}})",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Metrics}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "HTTP server - 500"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 51
+      },
+      "id": 73,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_status_code) (rate(http_client_duration_count{job=\"$Service\",http_status_code=~\"5.*\"}[$__rate_interval])) / ignoring(http_status_code) group_left sum(rate(http_client_duration_count{job=\"$Service\"}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "HTTP client - {{http_status_code}}",
           "range": true,
           "refId": "B"
         },
@@ -737,30 +1113,18 @@
             "uid": "${Metrics}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(rpc_client_duration_count{job=\"$Service\"} [$__rate_interval])) by (job, rpc_grpc_status_code)",
+          "expr": "sum by (rpc_grpc_status_code) (rate(rpc_client_duration_count{job=\"$Service\",rpc_grpc_status_code!=\"0\"}[$__rate_interval])) / ignoring(rpc_grpc_status_code) group_left sum(rate(rpc_client_duration_count{job=\"$Service\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "RPC client (status {{rpc_grpc_status_code}})",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Metrics}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(rpc_server_duration_count{job=\"$Service\"} [$__rate_interval])) by (job, rpc_grpc_status_code)",
-          "hide": false,
-          "legendFormat": "RPC server (status {{rpc_grpc_status_code}})",
           "range": true,
           "refId": "D"
         }
       ],
-      "title": "Rate",
+      "title": "Error rate",
       "type": "timeseries"
     }
   ],
-  "refresh": "5s",
+  "refresh": "",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],
@@ -826,6 +1190,6 @@
   "timezone": "",
   "title": "eBPF RED Metrics",
   "uid": "e0701985-a623-4e62-9fae-f5094244d065",
-  "version": 37,
+  "version": 54,
   "weekStart": ""
 }


### PR DESCRIPTION
Addressed some feedback from @fstab :

* In titles, replaced "client" and "server" by "outbound" and "inbound".
* Added two different rows per service, one for inbound and another for outbound traffic.
* Added error percentage rate chart. For server-side, an HTTP error is any 50x status code. For client-side, an HTTP error are any 50x or 40x status codes. For GRPC, in both cases is any non-zero status code.

<img width="1830" alt="image" src="https://github.com/grafana/ebpf-autoinstrument/assets/939550/0b37df48-2b94-4ba6-a9d1-cf830e5205c5">
