### PR TITLE
Don't fail if only PROMETHEUS_PORT is set

### DIFF
--- a/pkg/ebpf/httpfltr/httpfltr.go
+++ b/pkg/ebpf/httpfltr/httpfltr.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 
 	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
 	"github.com/grafana/ebpf-autoinstrument/pkg/exec"
@@ -214,7 +212,7 @@ func (p *Tracer) commNameOfDeadPid(pid uint32) string {
 		return ""
 	}
 
-	return string(cstr(name[:]))
+	return cstr(name[:])
 }
 
 func (p *Tracer) commName(pid uint32) string {
@@ -241,43 +239,4 @@ func (p *Tracer) serviceName(pid uint32) string {
 	name := p.commName(pid)
 	activePids.Add(pid, name)
 	return name
-}
-
-func findNamespace(pid int32) (uint32, error) {
-	pidPath := fmt.Sprintf("/proc/%d/ns/pid", pid)
-	f, err := os.Open(pidPath)
-
-	if err != nil {
-		return 0, fmt.Errorf("failed to open(/proc/%d/ns/pid): %w", pid, err)
-	}
-
-	defer f.Close()
-
-	// read the value of the symbolic link
-	buf := make([]byte, syscall.PathMax)
-	n, err := syscall.Readlink(pidPath, buf)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read symlink(/proc/%d/ns/pid): %w", pid, err)
-	}
-
-	logger := slog.With("component", "httpfltr.Tracer")
-
-	nsPid := string(buf[:n])
-	// extract u32 from the format pid:[nnnnn]
-	start := strings.LastIndex(nsPid, "[")
-	end := strings.LastIndex(nsPid, "]")
-
-	logger.Info("Found namespace", "nsPid", nsPid)
-
-	if start >= 0 && end >= 0 && end > start {
-		npid, err := strconv.ParseUint(string(buf[start+1:end]), 10, 32)
-
-		if err != nil {
-			return 0, fmt.Errorf("failed to parse ns pid %w", err)
-		}
-
-		return uint32(npid), nil
-	}
-
-	return 0, fmt.Errorf("couldn't find ns pid in the symlink [%s]", nsPid)
 }

--- a/pkg/ebpf/httpfltr/httpfltr_darwin.go
+++ b/pkg/ebpf/httpfltr/httpfltr_darwin.go
@@ -1,0 +1,6 @@
+package httpfltr
+
+func findNamespace(_ int32) (uint32, error) {
+	// convenience method to allow unit tests compiling in Darwin
+	return 1, nil
+}

--- a/pkg/ebpf/httpfltr/httpfltr_linux.go
+++ b/pkg/ebpf/httpfltr/httpfltr_linux.go
@@ -1,0 +1,50 @@
+package httpfltr
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/exp/slog"
+)
+
+func findNamespace(pid int32) (uint32, error) {
+	pidPath := fmt.Sprintf("/proc/%d/ns/pid", pid)
+	f, err := os.Open(pidPath)
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to open(/proc/%d/ns/pid): %w", pid, err)
+	}
+
+	defer f.Close()
+
+	// read the value of the symbolic link
+	buf := make([]byte, syscall.PathMax)
+	n, err := syscall.Readlink(pidPath, buf)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read symlink(/proc/%d/ns/pid): %w", pid, err)
+	}
+
+	logger := slog.With("component", "httpfltr.Tracer")
+
+	nsPid := string(buf[:n])
+	// extract u32 from the format pid:[nnnnn]
+	start := strings.LastIndex(nsPid, "[")
+	end := strings.LastIndex(nsPid, "]")
+
+	logger.Info("Found namespace", "nsPid", nsPid)
+
+	if start >= 0 && end >= 0 && end > start {
+		npid, err := strconv.ParseUint(string(buf[start+1:end]), 10, 32)
+
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse ns pid %w", err)
+		}
+
+		return uint32(npid), nil
+	}
+
+	return 0, fmt.Errorf("couldn't find ns pid in the symlink [%s]", nsPid)
+}

--- a/pkg/pipe/config.go
+++ b/pkg/pipe/config.go
@@ -84,10 +84,11 @@ func (c *Config) Validate() error {
 	}
 
 	if !c.Noop.Enabled() && !c.Printer.Enabled() &&
-		!c.Metrics.Enabled() && !c.Traces.Enabled() {
+		!c.Metrics.Enabled() && !c.Traces.Enabled() &&
+		!c.Prometheus.Enabled() {
 		return ConfigError("at least one of the following properties must be set: " +
 			"NOOP_TRACES, PRINT_TRACES, OTEL_EXPORTER_OTLP_ENDPOINT, " +
-			"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+			"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, PROMETHEUS_PORT")
 	}
 	return nil
 }

--- a/pkg/pipe/config_test.go
+++ b/pkg/pipe/config_test.go
@@ -74,6 +74,7 @@ func TestConfigValidate(t *testing.T) {
 		{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "localhost:1234", "EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar"},
 		{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "localhost:1234", "EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar"},
 		{"PRINT_TRACES": "true", "EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar"},
+		{"PROMETHEUS_PORT": "8080", "EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar"},
 	}
 	for n, tc := range testCases {
 		t.Run(fmt.Sprint("case", n), func(t *testing.T) {


### PR DESCRIPTION
Prometheus export is a valid export node itself, so the instrumenter should init even if no other exports are provided.

It also fixes a unit test not compiling in Darwin.