### PR TITLE
Fixing docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY Makefile Makefile
 RUN make compile
 
 # Create final image from minimal + built binary
-FROM busybox:1.36.1-glibc
+FROM ubuntu:latest
 
 LABEL maintainer="Grafana Labs <hello@grafana.com>"
 


### PR DESCRIPTION
The docker container image stopped working:
```
❯ docker run -it --rm grafana/ebpf-autoinstrument:latest
/otelauto: /lib/libc.so.6: version `GLIBC_2.32' not found (required by /otelauto)
/otelauto: /lib/libc.so.6: version `GLIBC_2.34' not found (required by /otelauto)
```

Looks like Go started to require a Glibc library that is not available in Busybox, so I replaced it by Ubuntu and it's working now.