### PR TITLE
Ordering imports formatting

### DIFF
--- a/cmd/otelauto/main.go
+++ b/cmd/otelauto/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
@@ -14,8 +15,6 @@ import (
 	"golang.org/x/exp/slog"
 
 	"github.com/grafana/ebpf-autoinstrument/pkg/pipe"
-
-	_ "net/http/pprof"
 )
 
 func main() {

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/ringbuf"
+
 	"github.com/grafana/ebpf-autoinstrument/pkg/goexec"
 )
 

--- a/pkg/ebpf/common/ringbuf.go
+++ b/pkg/ebpf/common/ringbuf.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/ringbuf"
-	"github.com/grafana/ebpf-autoinstrument/pkg/imetrics"
 	"github.com/mariomac/pipes/pkg/node"
 	"golang.org/x/exp/slog"
+
+	"github.com/grafana/ebpf-autoinstrument/pkg/imetrics"
 )
 
 // ringBufReader interface extracts the used methods from ringbuf.Reader for proper

--- a/pkg/ebpf/httpfltr/httpfltr_test.go
+++ b/pkg/ebpf/httpfltr/httpfltr_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf/ringbuf"
-	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
 	"github.com/stretchr/testify/assert"
+
+	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
 )
 
 const bufSize = 160

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -13,27 +13,21 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
-
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/mariomac/pipes/pkg/node"
+	"golang.org/x/exp/slog"
 	"golang.org/x/sys/unix"
 
+	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
 	"github.com/grafana/ebpf-autoinstrument/pkg/ebpf/goruntime"
 	"github.com/grafana/ebpf-autoinstrument/pkg/ebpf/grpc"
 	"github.com/grafana/ebpf-autoinstrument/pkg/ebpf/httpfltr"
-
-	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
-
-	"github.com/cilium/ebpf/rlimit"
-
-	"github.com/cilium/ebpf/link"
-
-	"github.com/cilium/ebpf"
+	"github.com/grafana/ebpf-autoinstrument/pkg/ebpf/nethttp"
 	"github.com/grafana/ebpf-autoinstrument/pkg/exec"
 	"github.com/grafana/ebpf-autoinstrument/pkg/goexec"
-
-	"github.com/grafana/ebpf-autoinstrument/pkg/ebpf/nethttp"
-	"github.com/mariomac/pipes/pkg/node"
-	"golang.org/x/exp/slog"
+	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
 )
 
 // Tracer is an individual eBPF program (e.g. the net/http or the grpc tracers)

--- a/pkg/ebpf/tracer_darwin.go
+++ b/pkg/ebpf/tracer_darwin.go
@@ -3,8 +3,9 @@ package ebpf
 import (
 	"context"
 
-	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
 	"github.com/mariomac/pipes/pkg/node"
+
+	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
 )
 
 // dummy functions and types to avoid compilation errors in Darwin. The tracer component is only usable in Linux.

--- a/pkg/exec/file.go
+++ b/pkg/exec/file.go
@@ -11,9 +11,8 @@ import (
 	"time"
 
 	"github.com/shirou/gopsutil/net"
-	"golang.org/x/exp/slog"
-
 	"github.com/shirou/gopsutil/process"
+	"golang.org/x/exp/slog"
 )
 
 // TODO: user-configurable

--- a/pkg/export/debug/debug.go
+++ b/pkg/export/debug/debug.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grafana/ebpf-autoinstrument/pkg/transform"
 	"github.com/mariomac/pipes/pkg/node"
+
+	"github.com/grafana/ebpf-autoinstrument/pkg/transform"
 )
 
 type PrintEnabled bool

--- a/pkg/export/otel/common.go
+++ b/pkg/export/otel/common.go
@@ -3,10 +3,11 @@ package otel
 import (
 	"context"
 
-	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+
+	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
 )
 
 // TODO: when we join both traces' and metrics ServiceName and ServiceNamespace into a common configuration section

--- a/pkg/export/otel/instrument.go
+++ b/pkg/export/otel/instrument.go
@@ -3,10 +3,11 @@ package otel
 import (
 	"context"
 
-	"github.com/grafana/ebpf-autoinstrument/pkg/imetrics"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/grafana/ebpf-autoinstrument/pkg/imetrics"
 )
 
 // instrumentedMetricsExporter wraps an otel metrics exporter to account some internal metrics

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -8,23 +8,19 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
-
-	"github.com/grafana/ebpf-autoinstrument/pkg/imetrics"
-
-	"go.opentelemetry.io/otel/sdk/instrumentation"
-
-	"go.opentelemetry.io/otel/sdk/metric/aggregation"
-
-	"golang.org/x/exp/slog"
-
-	"github.com/grafana/ebpf-autoinstrument/pkg/transform"
 	"github.com/mariomac/pipes/pkg/node"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"golang.org/x/exp/slog"
+
+	"github.com/grafana/ebpf-autoinstrument/pkg/imetrics"
+	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
+	"github.com/grafana/ebpf-autoinstrument/pkg/transform"
 )
 
 const (

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -7,15 +7,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/mariomac/pipes/pkg/node"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+
 	"github.com/grafana/ebpf-autoinstrument/pkg/imetrics"
 	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
 	"github.com/grafana/ebpf-autoinstrument/pkg/transform"
-	"github.com/mariomac/guara/pkg/test"
-	"github.com/mariomac/pipes/pkg/node"
-	"golang.org/x/exp/maps"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTracesEndpoint(t *testing.T) {

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/grafana/ebpf-autoinstrument/pkg/connector"
+	"github.com/mariomac/pipes/pkg/node"
+	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/grafana/ebpf-autoinstrument/pkg/connector"
 	"github.com/grafana/ebpf-autoinstrument/pkg/export/otel"
 	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
 	"github.com/grafana/ebpf-autoinstrument/pkg/transform"
-	"github.com/mariomac/pipes/pkg/node"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // using labels and names that are equivalent names to the OTEL attributes

--- a/pkg/goexec/offsets_test.go
+++ b/pkg/goexec/offsets_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/ebpf-autoinstrument/pkg/testutil"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/ebpf-autoinstrument/pkg/testutil"
 )
 
 // TestProcessNotFound tests that InspectOffsets process exits on context cancellation

--- a/pkg/goexec/structmembers.go
+++ b/pkg/goexec/structmembers.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/grafana/go-offsets-tracker/pkg/offsets"
 	"golang.org/x/exp/slog"
+
+	"github.com/grafana/go-offsets-tracker/pkg/offsets"
 )
 
 func log() *slog.Logger {

--- a/pkg/pipe/global/context.go
+++ b/pkg/pipe/global/context.go
@@ -3,9 +3,8 @@ package global
 import (
 	"context"
 
-	"github.com/grafana/ebpf-autoinstrument/pkg/imetrics"
-
 	"github.com/grafana/ebpf-autoinstrument/pkg/connector"
+	"github.com/grafana/ebpf-autoinstrument/pkg/imetrics"
 )
 
 type contextInfoKey struct{}

--- a/pkg/pipe/instrumenter.go
+++ b/pkg/pipe/instrumenter.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"golang.org/x/exp/slog"
-
 	"github.com/mariomac/pipes/pkg/graph"
 	"github.com/mariomac/pipes/pkg/node"
+	"golang.org/x/exp/slog"
 
 	"github.com/grafana/ebpf-autoinstrument/pkg/ebpf"
 	"github.com/grafana/ebpf-autoinstrument/pkg/export/debug"

--- a/pkg/pipe/instrumenter_test.go
+++ b/pkg/pipe/instrumenter_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/ebpf-autoinstrument/pkg/testutil"
-
 	"github.com/mariomac/pipes/pkg/graph"
 	"github.com/mariomac/pipes/pkg/node"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +17,7 @@ import (
 	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
 	"github.com/grafana/ebpf-autoinstrument/pkg/ebpf/httpfltr"
 	"github.com/grafana/ebpf-autoinstrument/pkg/export/otel"
+	"github.com/grafana/ebpf-autoinstrument/pkg/testutil"
 	"github.com/grafana/ebpf-autoinstrument/pkg/transform"
 	"github.com/grafana/ebpf-autoinstrument/test/collector"
 )

--- a/pkg/transform/routes.go
+++ b/pkg/transform/routes.go
@@ -4,9 +4,10 @@ package transform
 import (
 	"context"
 
-	"github.com/grafana/ebpf-autoinstrument/pkg/transform/route"
 	"github.com/mariomac/pipes/pkg/node"
 	"golang.org/x/exp/slog"
+
+	"github.com/grafana/ebpf-autoinstrument/pkg/transform/route"
 )
 
 // UnmatchType defines which actions to do when a route pattern is not recognized

--- a/pkg/transform/routes_test.go
+++ b/pkg/transform/routes_test.go
@@ -5,11 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/ebpf-autoinstrument/pkg/testutil"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const testTimeout = 5 * time.Second

--- a/pkg/transform/spanner.go
+++ b/pkg/transform/spanner.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"time"
 
-	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
-	httpfltr "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/httpfltr"
-
 	"github.com/gavv/monotime"
 	"golang.org/x/exp/slog"
+
+	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
+	httpfltr "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/httpfltr"
 )
 
 type EventType int

--- a/pkg/transform/spanner_test.go
+++ b/pkg/transform/spanner_test.go
@@ -3,10 +3,10 @@ package transform
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	ebpfcommon "github.com/grafana/ebpf-autoinstrument/pkg/ebpf/common"
 	"github.com/grafana/ebpf-autoinstrument/pkg/ebpf/httpfltr"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func cstr(s string) []byte {

--- a/test/cmd/grpc/client/client.go
+++ b/test/cmd/grpc/client/client.go
@@ -22,11 +22,12 @@ import (
 	"os"
 	"time"
 
-	pb "github.com/grafana/ebpf-autoinstrument/test/cmd/grpc/routeguide"
 	"golang.org/x/exp/slog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+
+	pb "github.com/grafana/ebpf-autoinstrument/test/cmd/grpc/routeguide"
 )
 
 var (

--- a/test/cmd/grpc/routeguide/route_guide.pb.go
+++ b/test/cmd/grpc/routeguide/route_guide.pb.go
@@ -10,10 +10,11 @@
 package routeguide
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/test/cmd/grpc/routeguide/route_guide_grpc.pb.go
+++ b/test/cmd/grpc/routeguide/route_guide_grpc.pb.go
@@ -8,6 +8,7 @@ package routeguide
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/test/cmd/grpc/server/server.go
+++ b/test/cmd/grpc/server/server.go
@@ -27,9 +27,7 @@ import (
 
 	"golang.org/x/exp/slog"
 	"google.golang.org/grpc"
-
 	"google.golang.org/grpc/credentials"
-
 	"google.golang.org/protobuf/proto"
 
 	pb "github.com/grafana/ebpf-autoinstrument/test/cmd/grpc/routeguide"

--- a/test/cmd/pingwrapper/wrapper.go
+++ b/test/cmd/pingwrapper/wrapper.go
@@ -11,11 +11,11 @@ import (
 	"strconv"
 	"time"
 
-	pb "github.com/grafana/ebpf-autoinstrument/test/cmd/grpc/routeguide"
+	"golang.org/x/exp/slog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"golang.org/x/exp/slog"
+	pb "github.com/grafana/ebpf-autoinstrument/test/cmd/grpc/routeguide"
 )
 
 const (

--- a/test/collector/collector.go
+++ b/test/collector/collector.go
@@ -11,12 +11,10 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.opentelemetry.io/collector/pdata/ptrace"
-
-	"golang.org/x/exp/slog"
-
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"golang.org/x/exp/slog"
 )
 
 // TestCollector is a dummy OLTP test collector that allows retrieving part of the collected metrics

--- a/test/integration/components/testserver/gin/gin.go
+++ b/test/integration/components/testserver/gin/gin.go
@@ -6,8 +6,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/arg"
 	"golang.org/x/exp/slog"
+
+	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/arg"
 )
 
 func Setup(port int) {

--- a/test/integration/components/testserver/gorilla/gorilla.go
+++ b/test/integration/components/testserver/gorilla/gorilla.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/std"
-
 	"github.com/gorilla/mux"
 	"golang.org/x/exp/slog"
+
+	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/std"
 )
 
 func Setup(port, stdPort int) {

--- a/test/integration/components/testserver/grpc/client/client.go
+++ b/test/integration/components/testserver/grpc/client/client.go
@@ -20,11 +20,12 @@ import (
 	"os"
 	"time"
 
-	pb "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/routeguide"
 	"golang.org/x/exp/slog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+
+	pb "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/routeguide"
 )
 
 var logs = slog.With("component", "grpc.Client")

--- a/test/integration/components/testserver/grpc/routeguide/route_guide.pb.go
+++ b/test/integration/components/testserver/grpc/routeguide/route_guide.pb.go
@@ -10,10 +10,11 @@
 package routeguide
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/test/integration/components/testserver/grpc/routeguide/route_guide_grpc.pb.go
+++ b/test/integration/components/testserver/grpc/routeguide/route_guide_grpc.pb.go
@@ -8,6 +8,7 @@ package routeguide
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/test/integration/components/testserver/grpc/server/server.go
+++ b/test/integration/components/testserver/grpc/server/server.go
@@ -26,9 +26,7 @@ import (
 
 	"golang.org/x/exp/slog"
 	"google.golang.org/grpc"
-
 	"google.golang.org/grpc/credentials"
-
 	"google.golang.org/protobuf/proto"
 
 	pb "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/routeguide"

--- a/test/integration/components/testserver/std/std.go
+++ b/test/integration/components/testserver/std/std.go
@@ -7,11 +7,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/arg"
-	pb "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/routeguide"
 	"golang.org/x/exp/slog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/arg"
+	pb "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/routeguide"
 )
 
 func HTTPHandler(log *slog.Logger, echoPort int) http.HandlerFunc {

--- a/test/integration/components/testserver/testserver.go
+++ b/test/integration/components/testserver/testserver.go
@@ -3,15 +3,14 @@ package main
 import (
 	"os"
 
-	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/gorilla"
-
-	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/gin"
-	grpctest "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/server"
-	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/std"
-
 	"github.com/caarlos0/env/v7"
 	gin2 "github.com/gin-gonic/gin"
 	"golang.org/x/exp/slog"
+
+	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/gin"
+	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/gorilla"
+	grpctest "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/server"
+	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/std"
 )
 
 /*

--- a/test/integration/internals_test.go
+++ b/test/integration/internals_test.go
@@ -7,10 +7,8 @@ import (
 	"testing"
 
 	"github.com/mariomac/guara/pkg/test"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/prometheus/common/expfmt"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/ebpf-autoinstrument/test/integration/components/prom"
-	grpcclient "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/client"
-
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/ebpf-autoinstrument/test/integration/components/prom"
+	grpcclient "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/client"
 )
 
 const (

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 	"time"
 
-	grpcclient "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/client"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/goccy/go-json"
-	"github.com/grafana/ebpf-autoinstrument/test/integration/components/jaeger"
 	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/ebpf-autoinstrument/test/integration/components/jaeger"
+	grpcclient "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/client"
 )
 
 func testHTTPTraces(t *testing.T) {


### PR DESCRIPTION
Integrating the `goimports-reviser` tool and check, during linter, that the files are properly formatted (can be done with the new  `make fmt` task).

Goimports-reviser is like goimports but it sorts the imports in 3 groups:

- Standard library
- Third-party libraries
- Local packages

It can be also configure to add any external `github.com/grafana` package between third-party and local packages.