### PR TITLE
Fix flaky tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ compile-for-coverage:
 .PHONY: test
 test:
 	@echo "### Testing code"
-	go test -mod vendor -a ./... -coverpkg=./... -coverprofile $(TEST_OUTPUT)/cover.all.txt
+	go test -race -mod vendor -a ./... -coverpkg=./... -coverprofile $(TEST_OUTPUT)/cover.all.txt
 
 .PHONY: cov-exclude-generated
 cov-exclude-generated:


### PR DESCRIPTION
There were some race conditions in the fakes/mocks that caused some tests to fail from time to time.

This PR also enables the `-race` flag in the unit tests and fixes the race warnings in the ringbuffer test.