### PR TITLE
Add dotnet integration tests for HTTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ test/integration/components/rubytestserver/testapi/storage/*
 test/integration/components/rubytestserver/testapi/tmp/storage/*
 !test/integration/components/rubytestserver/testapi/tmp/storage/
 !test/integration/components/rubytestserver/testapi/tmp/storage/.keep
+test/integration/components/dotnetserver/obj/Debug

--- a/test/integration/components/dotnetserver/Dockerfile
+++ b/test/integration/components/dotnetserver/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/sdk:latest
+
+# Set the working directory to /build
+WORKDIR /build
+
+# Copy the source code into the image for building
+COPY test/ test/
+
+WORKDIR /build/test/integration/components/dotnetserver
+
+EXPOSE 5266
+
+# Run the .net app
+CMD [ "dotnet", "run" ]

--- a/test/integration/components/dotnetserver/Dockerfile_tls
+++ b/test/integration/components/dotnetserver/Dockerfile_tls
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/sdk:latest
+
+# Set the working directory to /build
+WORKDIR /build
+
+# Copy the source code into the image for building
+COPY test/ test/
+
+WORKDIR /build/test/integration/components/dotnetserver
+
+EXPOSE 5266
+
+# Run the .net app
+CMD [ "dotnet", "run", "--launch-profile", "https"]

--- a/test/integration/components/dotnetserver/Program.cs
+++ b/test/integration/components/dotnetserver/Program.cs
@@ -1,7 +1,7 @@
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-app.MapGet("/ping", () => "PONG!");
+app.MapGet("/greeting", () => "PONG!");
 app.MapGet("/smoke", () => "");
 
 app.Run();

--- a/test/integration/components/dotnetserver/Program.cs
+++ b/test/integration/components/dotnetserver/Program.cs
@@ -1,0 +1,7 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/ping", () => "PONG!");
+app.MapGet("/smoke", () => "");
+
+app.Run();

--- a/test/integration/components/dotnetserver/Properties/launchSettings.json
+++ b/test/integration/components/dotnetserver/Properties/launchSettings.json
@@ -1,0 +1,37 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:62418",
+      "sslPort": 44341
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://0.0.0.0:5266",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://0.0.0.0:7033;http://0.0.0.0:5266",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/test/integration/components/dotnetserver/appsettings.Development.json
+++ b/test/integration/components/dotnetserver/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/test/integration/components/dotnetserver/appsettings.json
+++ b/test/integration/components/dotnetserver/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/test/integration/components/dotnetserver/dotnetserver.csproj
+++ b/test/integration/components/dotnetserver/dotnetserver.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/test/integration/components/dotnetserver/obj/dotnetserver.csproj.nuget.dgspec.json
+++ b/test/integration/components/dotnetserver/obj/dotnetserver.csproj.nuget.dgspec.json
@@ -1,0 +1,64 @@
+{
+  "format": 1,
+  "restore": {
+    "/home/nino/work/ebpf-autoinstrument/test/integration/components/dotnetserver/dotnetserver.csproj": {}
+  },
+  "projects": {
+    "/home/nino/work/ebpf-autoinstrument/test/integration/components/dotnetserver/dotnetserver.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "/home/nino/work/ebpf-autoinstrument/test/integration/components/dotnetserver/dotnetserver.csproj",
+        "projectName": "dotnetserver",
+        "projectPath": "/home/nino/work/ebpf-autoinstrument/test/integration/components/dotnetserver/dotnetserver.csproj",
+        "packagesPath": "/home/nino/.nuget/packages/",
+        "outputPath": "/home/nino/work/ebpf-autoinstrument/test/integration/components/dotnetserver/obj/",
+        "projectStyle": "PackageReference",
+        "configFilePaths": [
+          "/home/nino/.nuget/NuGet/NuGet.Config"
+        ],
+        "originalTargetFrameworks": [
+          "net7.0"
+        ],
+        "sources": {
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net7.0": {
+            "targetAlias": "net7.0",
+            "projectReferences": {}
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        }
+      },
+      "frameworks": {
+        "net7.0": {
+          "targetAlias": "net7.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.AspNetCore.App": {
+              "privateAssets": "none"
+            },
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "/usr/lib/dotnet/sdk/7.0.108/RuntimeIdentifierGraph.json"
+        }
+      }
+    }
+  }
+}

--- a/test/integration/components/dotnetserver/obj/dotnetserver.csproj.nuget.g.props
+++ b/test/integration/components/dotnetserver/obj/dotnetserver.csproj.nuget.g.props
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">$(MSBuildThisFileDirectory)project.assets.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">/home/nino/.nuget/packages/</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">/home/nino/.nuget/packages/</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">PackageReference</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">6.4.2</NuGetToolVersion>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <SourceRoot Include="/home/nino/.nuget/packages/" />
+  </ItemGroup>
+</Project>

--- a/test/integration/components/dotnetserver/obj/dotnetserver.csproj.nuget.g.targets
+++ b/test/integration/components/dotnetserver/obj/dotnetserver.csproj.nuget.g.targets
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />

--- a/test/integration/components/dotnetserver/obj/project.assets.json
+++ b/test/integration/components/dotnetserver/obj/project.assets.json
@@ -1,0 +1,69 @@
+{
+  "version": 3,
+  "targets": {
+    "net7.0": {}
+  },
+  "libraries": {},
+  "projectFileDependencyGroups": {
+    "net7.0": []
+  },
+  "packageFolders": {
+    "/home/nino/.nuget/packages/": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "/home/nino/work/ebpf-autoinstrument/test/integration/components/dotnetserver/dotnetserver.csproj",
+      "projectName": "dotnetserver",
+      "projectPath": "/home/nino/work/ebpf-autoinstrument/test/integration/components/dotnetserver/dotnetserver.csproj",
+      "packagesPath": "/home/nino/.nuget/packages/",
+      "outputPath": "/home/nino/work/ebpf-autoinstrument/test/integration/components/dotnetserver/obj/",
+      "projectStyle": "PackageReference",
+      "configFilePaths": [
+        "/home/nino/.nuget/NuGet/NuGet.Config"
+      ],
+      "originalTargetFrameworks": [
+        "net7.0"
+      ],
+      "sources": {
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "net7.0": {
+          "targetAlias": "net7.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      }
+    },
+    "frameworks": {
+      "net7.0": {
+        "targetAlias": "net7.0",
+        "imports": [
+          "net461",
+          "net462",
+          "net47",
+          "net471",
+          "net472",
+          "net48",
+          "net481"
+        ],
+        "assetTargetFallback": true,
+        "warn": true,
+        "frameworkReferences": {
+          "Microsoft.AspNetCore.App": {
+            "privateAssets": "none"
+          },
+          "Microsoft.NETCore.App": {
+            "privateAssets": "all"
+          }
+        },
+        "runtimeIdentifierGraphPath": "/usr/lib/dotnet/sdk/7.0.108/RuntimeIdentifierGraph.json"
+      }
+    }
+  }
+}

--- a/test/integration/components/dotnetserver/obj/project.nuget.cache
+++ b/test/integration/components/dotnetserver/obj/project.nuget.cache
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "dgSpecHash": "Wmo0FNrpwM2+JUMmmIq129ItivQQqQXKH8nfbhq1Wu2Er8Wr0kOgg7fBDLRdGDJylL14bLT9IBdKkplity6+UA==",
+  "success": true,
+  "projectFilePath": "/home/nino/work/ebpf-autoinstrument/test/integration/components/dotnetserver/dotnetserver.csproj",
+  "expectedPackageFiles": [],
+  "logs": []
+}

--- a/test/integration/docker-compose-dotnet.yml
+++ b/test/integration/docker-compose-dotnet.yml
@@ -1,0 +1,80 @@
+version: '3.8'
+
+services:
+  testserver:
+    build:
+      context: ../..
+      dockerfile: test/integration/components/dotnetserver/Dockerfile
+    image: hatest-testserver
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    depends_on:
+      otelcol:
+        condition: service_started
+
+  autoinstrumenter:
+    build:
+      context: ../..
+      dockerfile: ./test/integration/components/otelauto/Dockerfile
+    command:
+      - /otelauto
+      - --config=/configs/instrumenter-config-java.yml
+    volumes:
+      - ./configs/:/configs
+      - ../../testoutput:/coverage
+      - ../../testoutput/run:/var/run/otelauto
+    image: hatest-autoinstrumenter
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      GOCOVERDIR: "/coverage"
+      PRINT_TRACES: "true"
+      OPEN_PORT: "${OPEN_PORT}"
+      EXECUTABLE_NAME: "${EXECUTABLE_NAME}"
+      SERVICE_NAMESPACE: "integration-test"
+      METRICS_INTERVAL: "10ms"
+      BPF_BATCH_TIMEOUT: "10ms"
+      LOG_LEVEL: "DEBUG"
+      BPF_DEBUG: "TRUE"
+      METRICS_REPORT_TARGET: "true"
+      METRICS_REPORT_PEER: "true"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.77.0
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: [ "--config=/etc/otelcol-config/otelcol-config.yml" ]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317"          # OTLP over gRPC receiver
+      - "4318:4318"     # OTLP over HTTP receiver
+      - "9464"          # Prometheus exporter
+      - "8888"          # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v2.34.0
+    container_name: prometheus
+    command:
+      - --storage.tsdb.retention.time=30m
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"

--- a/test/integration/red_test_dotnet.go
+++ b/test/integration/red_test_dotnet.go
@@ -1,0 +1,18 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+)
+
+func testREDMetricsDotNetHTTP(t *testing.T) {
+	for _, testCaseURL := range []string{
+		"http://localhost:5267",
+	} {
+		t.Run(testCaseURL, func(t *testing.T) {
+			waitForTestComponents(t, testCaseURL)
+			testREDMetricsForNodeHTTPLibrary(t, testCaseURL, "dotnetserver") // reusing what we do for NodeJS
+		})
+	}
+}

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -206,3 +206,14 @@ func TestSuite_RailsTLS(t *testing.T) {
 	require.NoError(t, compose.Close())
 	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
 }
+
+func TestSuite_DotNet(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-dotnet.yml", path.Join(pathOutput, "test-suite-dotnet.log"))
+	compose.Env = append(compose.Env, `OPEN_PORT=5266`, `EXECUTABLE_NAME=`, `TEST_SERVICE_PORTS=5267:5266`)
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+	t.Run("DotNet RED metrics", testREDMetricsDotNetHTTP)
+	t.Run("BPF pinning folder mounted", testBPFPinningMounted)
+	require.NoError(t, compose.Close())
+	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
+}


### PR DESCRIPTION
This PR just adds a dotnet test for HTTP. HTTPS is built in the testcase, but we don't support HTTPS yet for .NET, it needs a bit of work and I'll follow up with that in another PR. The TLS story seems complex, there's a .NET library that's a port of OpenSSL with changed symbols for .net 6 and .net 7, but for .net 6 there's a separate port for OpenSSL with Quic.

I think our TLS support will work, we just need to match the symbols and the library names.