### PR TITLE
Add .net TLS support and tests

### DIFF
--- a/pkg/ebpf/httpfltr/httpfltr.go
+++ b/pkg/ebpf/httpfltr/httpfltr.go
@@ -172,6 +172,27 @@ func (p *Tracer) UProbes() map[string]map[string]ebpfcommon.FunctionPrograms {
 				Start:    p.bpfObjects.UprobeSslShutdown,
 			},
 		},
+		"libSystem.Security.Cryptography.Native.OpenSsl.so": {
+			"CryptoNative_SslRead": {
+				Required: false,
+				Start:    p.bpfObjects.UprobeSslRead,
+				End:      p.bpfObjects.UretprobeSslRead,
+			},
+			"CryptoNative_SslWrite": {
+				Required: false,
+				Start:    p.bpfObjects.UprobeSslWrite,
+				End:      p.bpfObjects.UretprobeSslWrite,
+			},
+			"CryptoNative_SslDoHandshake": {
+				Required: false,
+				Start:    p.bpfObjects.UprobeSslDoHandshake,
+				End:      p.bpfObjects.UretprobeSslDoHandshake,
+			},
+			"CryptoNative_SslShutdown": {
+				Required: false,
+				Start:    p.bpfObjects.UprobeSslShutdown,
+			},
+		},
 	}
 }
 

--- a/test/integration/components/dotnetserver/Dockerfile_tls
+++ b/test/integration/components/dotnetserver/Dockerfile_tls
@@ -8,7 +8,9 @@ COPY test/ test/
 
 WORKDIR /build/test/integration/components/dotnetserver
 
-EXPOSE 5266
+RUN dotnet dev-certs https
+
+EXPOSE 7033
 
 # Run the .net app
 CMD [ "dotnet", "run", "--launch-profile", "https"]

--- a/test/integration/docker-compose-dotnet.yml
+++ b/test/integration/docker-compose-dotnet.yml
@@ -4,7 +4,7 @@ services:
   testserver:
     build:
       context: ../..
-      dockerfile: test/integration/components/dotnetserver/Dockerfile
+      dockerfile: test/integration/components/dotnetserver/Dockerfile${TESTSERVER_DOCKERFILE_SUFFIX}
     image: hatest-testserver
     ports:
       - "${TEST_SERVICE_PORTS}"

--- a/test/integration/red_test_dotnet.go
+++ b/test/integration/red_test_dotnet.go
@@ -16,3 +16,14 @@ func testREDMetricsDotNetHTTP(t *testing.T) {
 		})
 	}
 }
+
+func testREDMetricsDotNetHTTPS(t *testing.T) {
+	for _, testCaseURL := range []string{
+		"https://localhost:7034",
+	} {
+		t.Run(testCaseURL, func(t *testing.T) {
+			waitForTestComponents(t, testCaseURL)
+			testREDMetricsForNodeHTTPLibrary(t, testCaseURL, "dotnetserver") // reusing what we do for NodeJS
+		})
+	}
+}

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -217,3 +217,14 @@ func TestSuite_DotNet(t *testing.T) {
 	require.NoError(t, compose.Close())
 	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
 }
+
+func TestSuite_DotNetTLS(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-dotnet.yml", path.Join(pathOutput, "test-suite-dotnet-tls.log"))
+	compose.Env = append(compose.Env, `OPEN_PORT=7033`, `EXECUTABLE_NAME=`, `TEST_SERVICE_PORTS=7034:7033`, `TESTSERVER_DOCKERFILE_SUFFIX=_tls`)
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+	t.Run("DotNet SSL RED metrics", testREDMetricsDotNetHTTPS)
+	t.Run("BPF pinning folder mounted", testBPFPinningMounted)
+	require.NoError(t, compose.Close())
+	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
+}


### PR DESCRIPTION
This PR adds support for tracking HTTPS requests in .net applications. .NET has a vendored version of OpenSSL, with some modifications and it's shipped as `libSystem.Security.Cryptography.Native.OpenSsl.so`. The signature of the functions we add probes to match, the only thing that's different is the symbol names.

I also fixed an issue with the Docker_tls file for .net and I added the test.

My understanding is that prior to .NET 6 they used OpenSSL as-is, which we support, but after .NET 6 this change was made. There's one combination we currently don't support in tracking HTTPS calls on .NET, which QUIC mode for .NET 6, where they used yet another library for that particular configuration https://devblogs.microsoft.com/dotnet/http-3-support-in-dotnet-6/. Since this is legacy and special case, I'd defer this to be added only if a customer is requesting it. 