### PR TITLE
Update offsets action issue #36

### DIFF
--- a/.github/workflows/update-offsets.yml
+++ b/.github/workflows/update-offsets.yml
@@ -1,0 +1,23 @@
+name: Update offsets
+on:
+  schedule:
+    - cron: '1 1 * * *'
+  workflow_dispatch:
+jobs:
+  UpdateOffsets:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout repo"
+      uses: actions/checkout@v3
+    - name: "Update offsets"
+      run: make update-offsets
+    - name: "Create/update PR"
+      uses: peter-evans/create-pull-request@v5
+      with:
+        commit-message: Automatic update of offsets.json
+        title: Automatic update of offsets.json
+        body: The offsets have been updated by go-offsets-tracker
+        base: main
+        branch: offset-content-auto-update
+        labels: automated-pr
+        delete-branch: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-*       @grcevski @mariomac
+*       @grcevski @mariomac @MattFrick
 
 # `make docs` procedure is owned by @jdbaldry of @grafana/docs-squad.
 /.github/workflows/update-make-docs.yml @jdbaldry


### PR DESCRIPTION
Add a daily update offsets Github action that runs "make update-offsets" and creates/updates a PR towards main from a fixed name branch: offset-content-auto-update.  Also add myself to CODEOWNERS.
The downside of automation is it's not easy to say what was updated, e.g. what is the new version of Go or GRPC, so the commit message/PR message is going to be static.  View of test PR in my fork:
![image](https://github.com/grafana/ebpf-autoinstrument/assets/37484314/2e86fe36-118c-4eb5-86ef-c1399cb6c905)
