### PR TITLE
Check and warn on insufficient permissions during process discovery

### DIFF
--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -79,6 +79,7 @@ func TracerProvider(ctx context.Context, cfg ebpfcommon.TracerConfig) ([]node.St
 	allFuncs := allGoFunctionNames(programs)
 	elfInfo, goffsets, err := inspect(ctx, &cfg, allFuncs)
 	if err != nil {
+		log.Error("Error inspecting", err)
 		return nil, fmt.Errorf("inspecting offsets: %w", err)
 	}
 


### PR DESCRIPTION
If we run without sufficient permissions we can't inspect the executable command line or the open file descriptors for all processes. We are currently swallowing those errors, some intentionally, some a library we use hides from us. There were too options here:

1. Stop the instrumenter once we find we don't have sufficient permissions to inspect a process.
2. Log a warning telling the user we can't look at a given process.

I opted for option 2. just to be future proof in case we manage to run with lowered permissions than CAP_ADMIN.

Closes https://github.com/grafana/ebpf-autoinstrument/issues/193