### PR TITLE
Update container creation

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -40,10 +40,11 @@ local docker_password_secret = secret('docker_password', 'infra/data/ci/docker_h
 
 local buildx(app) = {
   name: '%s-docker-buildx' % app,
-  image: 'thegeeklab/drone-docker-buildx:23',
+  image: 'thegeeklab/drone-docker-buildx:24',
   privileged: true,
   settings: {
     auto_tag: true,
+    tags: 'main',
     repo: 'grafana/%s' % app,
     dockerfile: 'Dockerfile',
     platforms: ['linux/%s' % arch for arch in archs],

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -2,11 +2,11 @@
 kind: pipeline
 name: ebpf-autoinstrument
 steps:
-- image: thegeeklab/drone-docker-buildx:23
+- image: thegeeklab/drone-docker-buildx:24
   name: ebpf-autoinstrument-dryrun-docker-buildx
   privileged: true
   settings:
-    auto_tag: true
+    auto_tag: false
     dockerfile: Dockerfile
     dry_run: true
     password:
@@ -15,12 +15,13 @@ steps:
     - linux/arm64
     - linux/amd64
     repo: grafana/ebpf-autoinstrument-dryrun
+    tags: test
     username:
       from_secret: docker_username
   when:
     event:
     - pull_request
-- image: thegeeklab/drone-docker-buildx:23
+- image: thegeeklab/drone-docker-buildx:24
   name: ebpf-autoinstrument-docker-buildx
   privileged: true
   settings:
@@ -33,12 +34,31 @@ steps:
     - linux/arm64
     - linux/amd64
     repo: grafana/ebpf-autoinstrument
+    tags: latest
+    username:
+      from_secret: docker_username
+  when:
+    event:
+    - tag
+- image: thegeeklab/drone-docker-buildx:24
+  name: ebpf-autoinstrument-main-docker-buildx
+  privileged: true
+  settings:
+    auto_tag: false
+    dockerfile: Dockerfile
+    dry_run: false
+    password:
+      from_secret: docker_password
+    platforms:
+    - linux/arm64
+    - linux/amd64
+    repo: grafana/ebpf-autoinstrument-main
+    tags: main
     username:
       from_secret: docker_username
   when:
     event:
     - push
-    - tag
 trigger:
   ref:
   - refs/heads/main
@@ -57,6 +77,6 @@ kind: secret
 name: docker_password
 ---
 kind: signature
-hmac: 3ba97e977eb91bed50eba8df4f1043a7fee5b7e857fb17431368e075876f5210
+hmac: 07573dab95399efe97ef0366ad71379d9aa922c35b0811bdba1824c71b13d4e0
 
 ...


### PR DESCRIPTION
Related issue: https://github.com/grafana/ebpf-autoinstrument/issues/196
* Updates drone buildx plugin to its last version
* `latest` tag is now only applied for released, tagged versions.
* `main` tag is applied for any commit into GitHub `main` branch.