### PR TITLE
Add test that demonstrates the status bug

### DIFF
--- a/test/integration/components/testserver/gorillamid/gorilla.go
+++ b/test/integration/components/testserver/gorillamid/gorilla.go
@@ -1,0 +1,28 @@
+package gorillamid
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"golang.org/x/exp/slog"
+
+	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/std"
+)
+
+func Setup(port, stdPort int) {
+	log := slog.With("component", "gorilla.Server")
+	r := mux.NewRouter()
+	r.PathPrefix("/").HandlerFunc(std.HTTPHandler(log, stdPort))
+
+	middlewares := []Interface{
+		StatusConcealer{},
+	}
+
+	h := Merge(middlewares...).Wrap(r)
+
+	address := fmt.Sprintf(":%d", port)
+	log.Info("starting HTTP server with middleware", "address", address)
+	err := http.ListenAndServe(address, h)
+	log.Error("HTTP server has unexpectedly stopped", err)
+}

--- a/test/integration/components/testserver/gorillamid/middleware.go
+++ b/test/integration/components/testserver/gorillamid/middleware.go
@@ -1,0 +1,28 @@
+package gorillamid
+
+import "net/http"
+
+// Interface is the shared contract for all middleware, and allows middlewares
+// to wrap handlers.
+type Interface interface {
+	Wrap(http.Handler) http.Handler
+}
+
+// Func is to Interface as http.HandlerFunc is to http.Handler
+type Func func(http.Handler) http.Handler
+
+// Wrap implements Interface
+func (m Func) Wrap(next http.Handler) http.Handler {
+	return m(next)
+}
+
+// Merge produces a middleware that applies multiple middlewares in turn;
+// ie Merge(f,g,h).Wrap(handler) == f.Wrap(g.Wrap(h.Wrap(handler)))
+func Merge(middlewares ...Interface) Interface {
+	return Func(func(next http.Handler) http.Handler {
+		for i := len(middlewares) - 1; i >= 0; i-- {
+			next = middlewares[i].Wrap(next)
+		}
+		return next
+	})
+}

--- a/test/integration/components/testserver/gorillamid/response.go
+++ b/test/integration/components/testserver/gorillamid/response.go
@@ -1,0 +1,59 @@
+package gorillamid
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// responseWriterSniffer properly handles responses that could not be written and exposes
+// the statusCode and the underlying error.
+type responseWriterSniffer struct {
+	rw         http.ResponseWriter
+	statusCode int
+	writeError error // The error returned when downstream Write() fails.
+}
+
+// newResponseWriterSniffer makes a new responseWriterSniffer.
+func newResponseWriterSniffer(rw http.ResponseWriter) *responseWriterSniffer {
+	return &responseWriterSniffer{
+		rw:         rw,
+		statusCode: http.StatusOK,
+	}
+}
+
+// Header returns the header map that will be sent by WriteHeader.
+// Implements ResponseWriter.
+func (b *responseWriterSniffer) Header() http.Header {
+	return b.rw.Header()
+}
+
+// Write writes HTTP response data.
+func (b *responseWriterSniffer) Write(data []byte) (int, error) {
+	if b.statusCode == 0 {
+		// WriteHeader has (probably) not been called, so we need to call it with StatusOK to fuflil the interface contract.
+		// https://godoc.org/net/http#ResponseWriter
+		b.WriteHeader(http.StatusOK)
+	}
+	n, err := b.rw.Write(data)
+	if err != nil {
+		b.writeError = err
+	}
+	return n, err
+}
+
+// WriteHeader writes the HTTP response header.
+func (b *responseWriterSniffer) WriteHeader(statusCode int) {
+	b.statusCode = statusCode
+	b.rw.WriteHeader(statusCode)
+}
+
+// Hijack hijacks the first response writer that is a Hijacker.
+func (b *responseWriterSniffer) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := b.rw.(http.Hijacker)
+	if ok {
+		return hj.Hijack()
+	}
+	return nil, nil, fmt.Errorf("responseWriterSniffer: can't cast underlying response writer to Hijacker")
+}

--- a/test/integration/components/testserver/gorillamid/statusConcealer.go
+++ b/test/integration/components/testserver/gorillamid/statusConcealer.go
@@ -1,0 +1,18 @@
+package gorillamid
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type StatusConcealer struct{}
+
+func (sc StatusConcealer) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wrapped := newResponseWriterSniffer(w)
+		next.ServeHTTP(wrapped, r)
+		statusCode, writeErr := wrapped.statusCode, wrapped.writeError
+
+		fmt.Printf("statusCode=%d, writeErr=%v\n", statusCode, writeErr)
+	})
+}

--- a/test/integration/components/testserver/testserver.go
+++ b/test/integration/components/testserver/testserver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/gin"
 	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/gorilla"
+	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/gorillamid"
 	grpctest "github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/grpc/server"
 	"github.com/grafana/ebpf-autoinstrument/test/integration/components/testserver/std"
 )
@@ -25,8 +26,10 @@ type config struct {
 	// GinPort to listen connections using the Gin framework
 	GinPort int `env:"GIN_PORT" envDefault:"8081"`
 	// GorillaPort to listen connections using the Gorilla Mux framework
-	GorillaPort int    `env:"GORILLA_PORT" envDefault:"8082"`
-	LogLevel    string `env:"LOG_LEVEL" envDefault:"INFO"`
+	GorillaPort int `env:"GORILLA_PORT" envDefault:"8082"`
+	// GorillaPort to listen connections using the Gorilla Mux framework, but using a middleware that has custom ResposeWriter
+	GorillaMidPort int    `env:"GORILLA_MID_PORT" envDefault:"8083"`
+	LogLevel       string `env:"LOG_LEVEL" envDefault:"INFO"`
 }
 
 func main() {
@@ -49,6 +52,10 @@ func main() {
 	}()
 	go func() {
 		gorilla.Setup(cfg.GorillaPort, cfg.STDPort)
+		close(wait)
+	}()
+	go func() {
+		gorillamid.Setup(cfg.GorillaMidPort, cfg.STDPort)
 		close(wait)
 	}()
 	go func() {


### PR DESCRIPTION
In this testcase we have a Go middleware that has its own implementation of ResponseWriter, which in turn stores the statusCode in it's own field.

I didn't add an integration test yet because it will fail.

Relates to https://github.com/grafana/ebpf-autoinstrument/issues/202