### PR TITLE
Add integration test case with DisableKeepAlives enabled #154

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ cleanup-integration-test:
 run-integration-test:
 	@echo "### Running integration tests"
 	go clean -testcache
-	go test -timeout 20m -mod vendor -a ./test/integration/... --tags=integration
+	go test -v -timeout 20m -mod vendor -a ./test/integration --tags=integration
 
 .PHONY: integration-test
 integration-test: prereqs prepare-integration-test

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -269,3 +269,20 @@ func TestSuite_PythonTLS(t *testing.T) {
 	require.NoError(t, compose.Close())
 	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
 }
+
+func TestSuite_DisableKeepAlives(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-disablekeepalives.log"))
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+
+	// Run tests with keepalives disabled:
+	setHTTPClientDisableKeepAlives(true)
+	t.Run("HTTP DisableKeepAlives traces", testHTTPTraces)
+	t.Run("Internal Prometheus DisableKeepAlives metrics", testInternalPrometheusExport)
+	// Reset to defaults for any tests run afterward
+	setHTTPClientDisableKeepAlives(false)
+
+	t.Run("BPF pinning folder mounted", testBPFPinningMounted)
+	require.NoError(t, compose.Close())
+	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
+}

--- a/test/integration/test_utils.go
+++ b/test/integration/test_utils.go
@@ -20,6 +20,10 @@ var tr = &http.Transport{
 }
 var testHTTPClient = &http.Client{Transport: tr}
 
+func setHTTPClientDisableKeepAlives(disableKeepAlives bool) {
+	testHTTPClient.Transport.(*http.Transport).DisableKeepAlives = disableKeepAlives
+}
+
 func doHTTPPost(t *testing.T, path string, status int, jsonBody []byte) {
 	req, err := http.NewRequest(http.MethodPost, path, bytes.NewReader(jsonBody))
 	require.NoError(t, err)

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -41,7 +41,7 @@ func testHTTPTraces(t *testing.T) {
 	require.NotEmpty(t, parent.TraceID)
 	require.NotEmpty(t, parent.SpanID)
 	// check duration is at least 10ms
-	assert.Less(t, 10*time.Millisecond, parent.Duration)
+	assert.Less(t, (10 * time.Millisecond).Microseconds(), parent.Duration)
 	// check span attributes
 	assert.Truef(t, parent.AllMatches(
 		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/ebpf-autoinstrument"},
@@ -127,7 +127,7 @@ func testGRPCTraces(t *testing.T) {
 	require.NotEmpty(t, parent.TraceID)
 	require.NotEmpty(t, parent.SpanID)
 	// check duration is at least 10ms (10,000 microseconds)
-	assert.Less(t, int64(10_000), parent.Duration)
+	assert.Less(t, (10 * time.Millisecond).Microseconds(), parent.Duration)
 	// check span attributes
 	assert.Truef(t, parent.AllMatches(
 		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/ebpf-autoinstrument"},


### PR DESCRIPTION
Fix time comparison in test code that caused failure in issue #154. Add simple trace/metric integration tests with DisableKeepAlives set to true. In arguments to "go test", add the verbose flag and remove "/..." from module path so that it prints out each test as it's running them.