### PR TITLE
Fix integration tests timeouts

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,4 @@
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -21,6 +21,7 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: Run integration tests
         run: make integration-test
+        timeout-minutes: 60
       - name: Upload integration test logs
         uses: actions/upload-artifact@v3
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ cleanup-integration-test:
 run-integration-test:
 	@echo "### Running integration tests"
 	go clean -testcache
-	go test -v -timeout 20m -mod vendor -a ./test/integration --tags=integration
+	go test -v -timeout 30m -mod vendor -a ./test/integration --tags=integration
 
 .PHONY: integration-test
 integration-test: prereqs prepare-integration-test

--- a/test/integration/config.go
+++ b/test/integration/config.go
@@ -6,5 +6,5 @@ var (
 	pathRoot     = path.Join("..", "..")
 	pathOutput   = path.Join(pathRoot, "testoutput")
 	pathVarRun   = path.Join(pathOutput, "run")
-	pathKindLogs = path.Join(pathOutput, "kind")
+	pathKindLogs = path.Join(pathOutput, "kind") //nolint:unused
 )

--- a/test/integration/config.go
+++ b/test/integration/config.go
@@ -3,8 +3,7 @@ package integration
 import "path"
 
 var (
-	pathRoot     = path.Join("..", "..")
-	pathOutput   = path.Join(pathRoot, "testoutput")
-	pathVarRun   = path.Join(pathOutput, "run")
-	pathKindLogs = path.Join(pathOutput, "kind") //nolint:unused
+	pathRoot   = path.Join("..", "..")
+	pathOutput = path.Join(pathRoot, "testoutput")
+	pathVarRun = path.Join(pathOutput, "run")
 )

--- a/test/integration/k8s_test.go
+++ b/test/integration/k8s_test.go
@@ -1,10 +1,11 @@
-//go:build integration
+//go:build integration_ignore_by_now
 
 package integration
 
 import (
 	"net/http"
 	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -17,12 +18,13 @@ import (
 	"github.com/grafana/ebpf-autoinstrument/test/integration/components/prom"
 )
 
-// nolint:unused
+const (
+	pathKindLogs = path.Join(pathOutput, "kind")
+)
+
 var cluster *kube.Kind
 
-// TODO: unskip when we require testing Kubernetes features
-// nolint
-func skipTestMain(m *testing.M) {
+func TestMain(m *testing.M) {
 	if err := docker.Build(os.Stdout, "../..",
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: "components/testserver/Dockerfile"},
 		docker.ImageBuild{Tag: "beyla:dev", Dockerfile: "components/beyla/Dockerfile"},
@@ -46,8 +48,7 @@ func skipTestMain(m *testing.M) {
 	cluster.Run(m)
 }
 
-func TestK8sSmoke(t *testing.T) {
-	t.Skip("we don't require Kubernetes testing right now")
+func TestSmoke(t *testing.T) {
 	// smoke test that just waits until all the components are up and
 	// applications traces are reported are traced
 	const (

--- a/test/integration/k8s_test.go
+++ b/test/integration/k8s_test.go
@@ -17,9 +17,12 @@ import (
 	"github.com/grafana/ebpf-autoinstrument/test/integration/components/prom"
 )
 
+// nolint:unused
 var cluster *kube.Kind
 
-func TestMain(m *testing.M) {
+// TODO: unskip when we require testing Kubernetes features
+// nolint
+func skipTestMain(m *testing.M) {
 	if err := docker.Build(os.Stdout, "../..",
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: "components/testserver/Dockerfile"},
 		docker.ImageBuild{Tag: "beyla:dev", Dockerfile: "components/beyla/Dockerfile"},
@@ -43,7 +46,8 @@ func TestMain(m *testing.M) {
 	cluster.Run(m)
 }
 
-func TestSmoke(t *testing.T) {
+func TestK8sSmoke(t *testing.T) {
+	t.Skip("we don't require Kubernetes testing right now")
 	// smoke test that just waits until all the components are up and
 	// applications traces are reported are traced
 	const (


### PR DESCRIPTION
Increases the `make integration-tests` step timeout to 60 minutes, to avoid premature killing.

Also disables temporarily the kubernetes tests, as we don't need them at the moment.

Also tries to fix Codecov to avoid premature reporting of coverage data (e.g. report unit tests coverage before waiting for integration tests to finish)