### PR TITLE
Fix missing /internal path to offsets.json and in README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,8 @@ lint: prereqs checkfmt
 
 .PHONY: update-offsets
 update-offsets: prereqs
-	@echo "### Updating pkg/goexec/offsets.json"
-	$(GO_OFFSETS_TRACKER) -i configs/offsets/tracker_input.json pkg/goexec/offsets.json
+	@echo "### Updating pkg/internal/goexec/offsets.json"
+	$(GO_OFFSETS_TRACKER) -i configs/offsets/tracker_input.json pkg/internal/goexec/offsets.json
 
 # As generated artifacts are part of the code repo (pkg/ebpf packages), you don't have
 # to run this target for each build. Only when you change the C code inside the bpf folder.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You should be able to query traces and metrics in your Grafana board.
 
 ### How to regenerate the eBPF Kernel binaries
 
-The eBPF program is embedded into the `pkg/ebpf/bpf_*` generated files.
+The eBPF program is embedded into the `pkg/internal/ebpf/bpf_*` generated files.
 This step is generally not needed unless you change the C code in the `bpf` folder.
 
 If you have Docker installed, you just need to run:


### PR DESCRIPTION
Quick fix to path on offsets.json in the Makefile, which was causing the update-offsets action to start from scratch and go back through many golang versions.