### PR TITLE
Add app cluster example

### DIFF
--- a/examples/greeting-apps/configs/agent-config.river
+++ b/examples/greeting-apps/configs/agent-config.river
@@ -1,0 +1,47 @@
+logging {
+  level  = "debug"
+  format = "logfmt"
+}
+
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4017"
+  }
+  http {
+    endpoint = "0.0.0.0:4018"
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+    traces = [otelcol.processor.batch.default.input]
+  }
+}
+  
+otelcol.processor.batch "default" {
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+    traces  = [otelcol.exporter.otlp.tempo.input]
+  }
+}
+
+otelcol.exporter.prometheus "default" {
+  include_target_info = true
+  include_scope_info = true
+  forward_to = [prometheus.remote_write.mimir.receiver]
+}
+  
+prometheus.remote_write "mimir" {
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+  }
+}
+
+otelcol.exporter.otlp "tempo" {
+    client {
+        endpoint = "tempo:4317"
+        tls {
+            insecure             = true
+            insecure_skip_verify = true
+        }
+    }
+}

--- a/examples/greeting-apps/configs/beyla-config.yml
+++ b/examples/greeting-apps/configs/beyla-config.yml
@@ -1,0 +1,5 @@
+routes:
+  patterns:
+    - /smoke
+    - /greeting
+  unmatch: path

--- a/examples/greeting-apps/configs/beyla-config.yml
+++ b/examples/greeting-apps/configs/beyla-config.yml
@@ -2,4 +2,5 @@ routes:
   patterns:
     - /smoke
     - /greeting
+    - /ping
   unmatch: path

--- a/examples/greeting-apps/configs/mimir-config.yaml
+++ b/examples/greeting-apps/configs/mimir-config.yaml
@@ -1,0 +1,47 @@
+# Do not use this configuration in production.
+# It is for demonstration purposes only.
+multitenancy_enabled: false
+
+blocks_storage:
+  backend: filesystem
+  bucket_store:
+    sync_dir: /tmp/mimir/tsdb-sync
+  filesystem:
+    dir: /tmp/mimir/data/tsdb
+  tsdb:
+    dir: /tmp/mimir/tsdb
+
+compactor:
+  data_dir: /tmp/mimir/compactor
+  sharding_ring:
+    kvstore:
+      store: memberlist
+
+distributor:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: memberlist
+
+ingester:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: memberlist
+    replication_factor: 1
+
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/mimir/rules
+
+server:
+  http_listen_port: 9009
+  log_level: error
+
+store_gateway:
+  sharding_ring:
+    replication_factor: 1
+
+limits:
+  max_global_exemplars_per_user: 100000

--- a/examples/greeting-apps/configs/nginx.conf
+++ b/examples/greeting-apps/configs/nginx.conf
@@ -1,0 +1,34 @@
+events {}
+
+http {
+    server {
+        listen 3330;
+
+        location /greeting {
+            proxy_pass http://javatestserver:8085/greeting;
+            proxy_set_header X-Real-IP  $remote_addr;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+        }
+
+        location /smoke {
+            proxy_pass http://rusttestserver:8090/smoke;
+            proxy_set_header X-Real-IP  $remote_addr;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+        }
+
+        location /ping {
+            proxy_pass http://gotestserver:8080/ping;
+            proxy_set_header X-Real-IP  $remote_addr;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+        }
+    }
+}

--- a/examples/greeting-apps/configs/tempo-config.yaml
+++ b/examples/greeting-apps/configs/tempo-config.yaml
@@ -1,0 +1,40 @@
+# Do not use this configuration in production.
+# It is for demonstration purposes only.
+# metrics_generator_enabled: true
+# search_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+        grpc:
+
+metrics_generator:
+  ring:
+    kvstore: {}
+  processor:
+    service_graphs: {}
+    span_metrics: {}
+  registry:
+    external_labels:
+      source: tempo
+  storage:
+    path: /tmp/tempo/generator/wal
+    remote_write:
+      - url: http://mimir:9009/api/v1/push
+        send_exemplars: true
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /tmp/tempo/wal
+    local:
+      path: /tmp/tempo/blocks
+
+overrides:
+  metrics_generator_processors: ["service-graphs", "span-metrics"]

--- a/examples/greeting-apps/docker-compose.yaml
+++ b/examples/greeting-apps/docker-compose.yaml
@@ -1,0 +1,176 @@
+version: '3.8'
+
+services:
+  nginx:
+    image: nginx:latest
+    container_name: demo-nginx
+    ports:
+      - 3333:3330
+    volumes:
+      - ./configs/:/etc/nginx
+    depends_on:
+      gotestserver:
+        condition: service_started
+      javatestserver:
+        condition: service_started
+      rusttestserver:
+        condition: service_started
+
+  # Beyla for NGINX
+  nginxbeyla:
+    image: grafana/ebpf-autoinstrument:latest
+    command:
+      - /otelauto
+      - --config=/configs/beyla-config.yml
+    volumes:
+      - ./configs/:/configs
+    container_name: demo-nginxbeyla
+    privileged: true 
+    network_mode: "service:nginx"
+    pid: "service:nginx"
+    environment:
+      PRINT_TRACES: "true"
+      OPEN_PORT: "3330"
+      SERVICE_NAMESPACE: "demo"
+      OTEL_SERVICE_NAME: "demo-nginx"
+      LOG_LEVEL: "DEBUG"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://agent:4018"
+    depends_on:
+      nginx:
+        condition: service_started
+
+  # Go test server
+  # Test server source can be found at test/integration/components/testserver
+  gotestserver:
+    image: ghcr.io/grafana/beyla-demo/greeting-go/0.0.1
+    container_name: demo-gotestserver
+    #ports:
+    #  - "8084:8080"
+
+  # Beyla for Java Spring Boot 3.0 GraalVM Native Image
+  gobeyla:
+    image: grafana/ebpf-autoinstrument:latest
+    command:
+      - /otelauto
+      - --config=/configs/beyla-config.yml
+    volumes:
+      - ./configs/:/configs
+    container_name: demo-gobeyla
+    privileged: true 
+    network_mode: "service:gotestserver"
+    pid: "service:gotestserver"
+    environment:
+      PRINT_TRACES: "true"
+      OPEN_PORT: "8080"
+      SERVICE_NAMESPACE: "demo"
+      OTEL_SERVICE_NAME: "demo-go-service"
+      LOG_LEVEL: "DEBUG"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://agent:4018"
+    depends_on:
+      gotestserver:
+        condition: service_started
+
+  # Java Spring Boot 3.0 GraalVM Native Image test server
+  # Test server source can be found at test/integration/components/javatestserver
+  javatestserver:
+    image: ghcr.io/grafana/beyla-demo/greeting-graalvm-native/0.0.1
+    container_name: demo-javatestserver
+    #ports:
+    #  - "8085:8085"
+
+  # Beyla for Java Spring Boot 3.0 GraalVM Native Image
+  javabeyla:
+    image: grafana/ebpf-autoinstrument:latest
+    command:
+      - /otelauto
+      - --config=/configs/beyla-config.yml
+    volumes:
+      - ./configs/:/configs
+    container_name: demo-javabeyla
+    privileged: true 
+    network_mode: "service:javatestserver"
+    pid: "service:javatestserver"
+    environment:
+      PRINT_TRACES: "true"
+      OPEN_PORT: "8085"
+      SERVICE_NAMESPACE: "demo"
+      OTEL_SERVICE_NAME: "demo-graalvm-native-service"
+      LOG_LEVEL: "DEBUG"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://agent:4018"
+    depends_on:
+      javatestserver:
+        condition: service_started
+
+  # Rust Actix test server
+  # Test server source can be found at test/integration/components/rusttestserver
+  rusttestserver:
+    image: ghcr.io/grafana/beyla-demo/greeting-actix-rust/0.0.1
+    container_name: demo-rusttestserver
+    #ports:
+    #  - "8086:8090"
+
+  # Beyla for Rust Actix
+  rustbeyla:
+    image: grafana/ebpf-autoinstrument:latest
+    command:
+      - /otelauto
+      - --config=/configs/beyla-config.yml
+    volumes:
+      - ./configs/:/configs
+    container_name: demo-rustbeyla
+    privileged: true 
+    network_mode: "service:rusttestserver"
+    pid: "service:rusttestserver"
+    environment:
+      PRINT_TRACES: "true"
+      OPEN_PORT: "8090"
+      SERVICE_NAMESPACE: "demo"
+      OTEL_SERVICE_NAME: "demo-rust-service"
+      LOG_LEVEL: "DEBUG"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://agent:4018"
+    depends_on:
+      rusttestserver:
+        condition: service_started
+
+  # Grafana Agent
+  agent:
+    image: grafana/agent
+    container_name: demo-agent
+    command:
+      - run
+      - /etc/agent/agent-config.river
+    volumes:
+      - ./configs/:/etc/agent
+    environment:
+      AGENT_MODE: "flow"
+    ports:
+      - "4017:4017"
+      - "4018:4018"
+
+  # Tempo
+  tempo:
+    image: grafana/tempo
+    container_name: demo-tempo
+    command:
+      - -config.file 
+      - /etc/tempo/tempo-config.yaml
+    volumes:
+      - ./configs/:/etc/tempo
+    ports:
+      - "3200:3200"
+      - "4317:4317"
+      - "4318:4318"
+
+  # Mimir -config.file=config-mimir.yaml -server.grpc-listen-port=9096
+  mimir:
+    image: grafana/mimir
+    container_name: demo-mimir
+    command:
+      - -config.file=/etc/mimir/mimir-config.yaml
+      - -server.grpc-listen-port=9096
+    volumes:
+      - ./configs/:/etc/mimir
+    ports:
+      - "9009:9009"
+      - "9096:9096"
+

--- a/examples/greeting-apps/loadgen.sh
+++ b/examples/greeting-apps/loadgen.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+BASE_URL=${BASE_URL:-"http://localhost:3333"}
+
+URLS=(
+  "/greeting"
+  "/smoke"
+  "/ping?delay=300ms"
+)
+URLS_LEN=${#URLS[@]}
+
+while true; do
+  # shellcheck disable=SC2004
+  URL_IDX=$((${RANDOM} % ${URLS_LEN}))
+  URL="${BASE_URL}${URLS[$URL_IDX]}"
+  echo "calling ${URL}"
+  curl -k  "${URL}" > /dev/null
+
+  sleep "$(echo "scale=4;${URL_IDX} / ${URLS_LEN}0 " | bc)"
+done

--- a/test/integration/components/javatestserver/Dockerfile
+++ b/test/integration/components/javatestserver/Dockerfile
@@ -10,7 +10,7 @@ RUN microdnf update \
 
 # Install Maven
 ARG USER_HOME_DIR="/cache"
-ARG MAVEN_DOWNLOAD_URL=https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz
+ARG MAVEN_DOWNLOAD_URL=https://dlcdn.apache.org/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && curl -L -o /tmp/apache-maven.tar.gz ${MAVEN_DOWNLOAD_URL} \

--- a/test/integration/components/rusttestserver/Cargo.toml
+++ b/test/integration/components/rusttestserver/Cargo.toml
@@ -10,3 +10,4 @@ json = "0.12"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
+rand = "0.8.5"

--- a/test/integration/components/rusttestserver/src/main.rs
+++ b/test/integration/components/rusttestserver/src/main.rs
@@ -1,5 +1,8 @@
 use actix_web::{middleware, web, App, HttpResponse, HttpServer};
 use serde::{Deserialize, Serialize};
+use rand::Rng;
+use std::time::Duration;
+use std::thread;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct MyObj {
@@ -9,11 +12,14 @@ struct MyObj {
 
 /// This handler uses json extractor
 async fn greeting(item: web::Json<MyObj>) -> HttpResponse {
-    println!("model: {:?}", &item);
+    //println!("model: {:?}", &item);
     HttpResponse::Ok().json(item.0) // <- send response
 }
 
 async fn smoke() -> HttpResponse {
+    let mut rng = rand::thread_rng();
+    let sleep_time = rng.gen_range(100..500);
+    thread::sleep(Duration::from_millis(sleep_time));
     HttpResponse::Ok().into()
 }
 


### PR DESCRIPTION
This PR adds a docker compose example of a cluster of applications running behind an ngix proxy. Essentially, we use our Go, Rust and GraalVM Native examples, setup Grafana Agent, Tempo, Mimir and drive some load to the services.

I plan to use this example setup to make an introduction video for Beyla.