### PR TITLE
Add option to enable trace sampling

### DIFF
--- a/docs/sources/config/index.md
+++ b/docs/sources/config/index.md
@@ -370,6 +370,15 @@ If set to `true`, the OTEL client accepts any certificate presented by the serve
 and any host name in that certificate. In this mode, TLS is susceptible to a man-in-the-middle
 attacks. This option should be used only for testing and development purposes.
 
+| YAML                   | Env var                     | Type | Default |
+|------------------------|-----------------------------|------|---------|
+| `sampling_ratio` | `OTEL_TRACE_SAMPLING_RATIO` | float | `1.0` |
+
+Specifies the ratio of generated traces that will be sampled for sending to an OTEL collector.
+By default, all traces are sampled, meaning that all traces will be sent downstream. In production, you
+may want to lower this number to reduce the amount of generated trace data. If you are using the
+Grafana Agent as your OTEL collector, you can configure the sampling policy at that level instead.
+
 ## Prometheus HTTP endpoint
 
 YAML section `prometheus_export`.

--- a/pkg/internal/export/otel/traces.go
+++ b/pkg/internal/export/otel/traces.go
@@ -51,9 +51,10 @@ type TracesConfig struct {
 	// InsecureSkipVerify is not standard, so we don't follow the same naming convention
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"OTEL_INSECURE_SKIP_VERIFY"`
 
+	SamplingRatio float64 `yaml:"sampling_ratio" env:"OTEL_TRACE_SAMPLING_RATIO"`
+
 	// Configuration options below this line will remain undocumented at the moment,
 	// but can be useful for performance-tuning of some customers.
-
 	MaxExportBatchSize int           `yaml:"max_export_batch_size" env:"OTLP_TRACES_MAX_EXPORT_BATCH_SIZE"`
 	MaxQueueSize       int           `yaml:"max_queue_size" env:"OTLP_TRACES_MAX_QUEUE_SIZE"`
 	BatchTimeout       time.Duration `yaml:"batch_timeout" env:"OTLP_TRACES_BATCH_TIMEOUT"`
@@ -134,6 +135,7 @@ func newTracesReporter(ctx context.Context, cfg *TracesConfig, ctxInfo *global.C
 	r.traceProvider = trace.NewTracerProvider(
 		trace.WithResource(resource),
 		trace.WithSpanProcessor(r.bsp),
+		trace.WithSampler(trace.ParentBased(trace.TraceIDRatioBased(cfg.SamplingRatio))),
 	)
 
 	return &r, nil

--- a/pkg/internal/pipe/config.go
+++ b/pkg/internal/pipe/config.go
@@ -33,6 +33,7 @@ var defaultConfig = Config{
 		Protocol:           otel.ProtocolHTTPProtobuf,
 		MaxQueueSize:       4096,
 		MaxExportBatchSize: 4096,
+		SamplingRatio:      1.0,
 	},
 	Prometheus: prom.PrometheusConfig{
 		Path:    "/metrics",

--- a/pkg/internal/pipe/config_test.go
+++ b/pkg/internal/pipe/config_test.go
@@ -75,6 +75,7 @@ kubernetes:
 			TracesEndpoint:     "localhost:3232",
 			MaxQueueSize:       4096,
 			MaxExportBatchSize: 4096,
+			SamplingRatio:      1.0,
 		},
 		Prometheus: prom.PrometheusConfig{
 			Path: "/metrics",

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -74,7 +74,7 @@ func TestTracerPipeline(t *testing.T) {
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint}}, gctx(), &ebpf.ProcessTracer{})
+	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0}}, gctx(), &ebpf.ProcessTracer{})
 	// Override eBPF tracer to send some fake data
 	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {
@@ -199,7 +199,7 @@ func TestTraceGRPCPipeline(t *testing.T) {
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint}}, gctx(), &ebpf.ProcessTracer{})
+	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0}}, gctx(), &ebpf.ProcessTracer{})
 	// Override eBPF tracer to send some fake data
 	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {
@@ -226,7 +226,7 @@ func TestNestedSpanMatching(t *testing.T) {
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint}}, gctx(), &ebpf.ProcessTracer{})
+	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0}}, gctx(), &ebpf.ProcessTracer{})
 	// Override eBPF tracer to send some fake data with nested client span
 	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {
@@ -499,7 +499,7 @@ func TestTracerPipelineInfo(t *testing.T) {
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint}}, gctx(), &ebpf.ProcessTracer{})
+	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0}}, gctx(), &ebpf.ProcessTracer{})
 	// Override eBPF tracer to send some fake data
 	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {


### PR DESCRIPTION
This PR adds a configuration option to enable trace generation sampling. Sampling with ParentBased and TraceIDRatio are recommended as per the OTEL spec https://opentelemetry.io/docs/instrumentation/go/sampling/.

By default our sampling remains at 1.0, which means everything is sent, however it can be configured as little as 0.